### PR TITLE
Issue #5: add `--shallow` option to `list-machines`

### DIFF
--- a/cockpit/leapp.html
+++ b/cockpit/leapp.html
@@ -57,7 +57,8 @@
         }
 
         function list_local_vms() {
-            var proc = call_leapp(["list-machines"]);
+            var proc = call_leapp(["list-machines", "--shallow"]);
+            // TODO: Add activity spinner
             proc.done(refresh_vm_table);
             proc.fail(list_local_vms_fail);
 

--- a/leapp-tool.py
+++ b/leapp-tool.py
@@ -34,6 +34,7 @@ parser = ap.add_subparsers(help='sub-command', dest='action')
 list_cmd = parser.add_parser('list-machines', help='list running virtual machines and some information')
 migrate_cmd = parser.add_parser('migrate-machine', help='migrate source VM to a target container host')
 
+list_cmd.add_argument('--shallow', action='store_true', help='target VM name ')
 list_cmd.add_argument('pattern', nargs='*', default=['*'], help='list machines matching pattern')
 
 migrate_cmd.add_argument('machine', help='source machine to migrate')
@@ -103,7 +104,7 @@ class MigrationContext:
 
 parsed = ap.parse_args()
 if parsed.action == 'list-machines':
-    lmp = LibvirtMachineProvider()
+    lmp = LibvirtMachineProvider(parsed.shallow)
     print(dumps({'machines': [m._to_dict() for m in lmp.get_machines()]}, indent=3))
 
 elif parsed.action == 'migrate-machine':

--- a/leappto/providers/libvirt_provider.py
+++ b/leappto/providers/libvirt_provider.py
@@ -5,8 +5,9 @@ from subprocess import check_output
 
 
 class LibvirtMachineProvider(AbstractMachineProvider):
-    def __init__(self):
+    def __init__(self, shallow_scan=True):
         self._connection = libvirt.open('qemu:///system')
+        self._shallow_scan = shallow_scan
         # Stupid `libvirt` cannot carry out certain *read only* operations while
         # being in read-only mode so just use `open` and fix this later by enumerating
         # networks, checking the MAC of the domain and correlating this against DHCP leases
@@ -98,7 +99,10 @@ class LibvirtMachineProvider(AbstractMachineProvider):
             :param domain_name: str, which domain to inspect
             :return:
             """
-            os_data = check_output(['virt-inspector', '-d', domain_name])
+            cmd = ['virt-inspector', '-d', domain_name, '--no-icon']
+            if self._shallow_scan:
+                cmd.append('--no-applications')
+            os_data = check_output(cmd)
             root = ET.fromstring(os_data)
             packages = []
 


### PR DESCRIPTION
Also switches the Cockpit plugin over to using the new option,
so the list refreshes in ~3 seconds rather than ~10.