### PR TITLE
Initial integration testing environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .vagrant/
 __pycache__/
 *.pyc
+# Symlink to virtualenv
+.venv

--- a/Pipfile
+++ b/Pipfile
@@ -3,10 +3,10 @@ url = "https://pypi.python.org/simple"
 verify_ssl = true
 
 [dev-packages]
-pylint = "*"
-
-[packages]
 behave = "*"
-ansible = ">= 2.0"
+pylint = "*"
 requests = "*"
 PyHamcrest = "*"
+
+[packages]
+ansible = ">= 2.0"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "4713f05e1b1892646f7ae415a98708f0dafb1db5d9ceeeab65f0734a2a0b4f97"
+            "sha256": "2e44e32d168e660c33500909dad6f514aa4c5fa49fc50e802697bec5d76c59fa"
         },
         "requires": {},
         "sources": [
@@ -20,10 +20,6 @@
             "hash": "sha256:a6be69091dac236ea9c6bc7d012beab42010fa914c459791d627dad4910eb665",
             "version": "==1.0"
         },
-        "PyHamcrest": {
-            "hash": "sha256:6b672c02fdf7470df9674ab82263841ce8333fb143f32f021f6cb26f0e512420",
-            "version": "==1.9.0"
-        },
         "PyYAML": {
             "hash": "sha256:592766c6303207a20efc445587778322d7f73b161bd994f227adaa341ba212ab",
             "version": "==3.12"
@@ -40,13 +36,9 @@
             "hash": "sha256:d232509fefcfcdb9a331f37e9c9dc20441019ad927c7d2176cf18ed5da0ba097",
             "version": "==0.22.0"
         },
-        "behave": {
-            "hash": "sha256:89238a5e4b11ff607e8ebc6b4b1fb1a0b1f3d794fba80e1fb4b6b3652979c927",
-            "version": "==1.2.5"
-        },
         "cffi": {
-            "hash": "sha256:a7930e73a4359b52323d09de6d6860840314aa09346cbcf4def8875e1b07ebc7",
-            "version": "==1.9.1"
+            "hash": "sha256:4fc9c2ff7924b3a1fa326e1799e5dd58cac585d7fb25fe53ccaa1333b0453d65",
+            "version": "==1.10.0"
         },
         "cryptography": {
             "hash": "sha256:323524312bb467565ebca7e50c8ae5e9674e544951d28a2904a50012a8828190",
@@ -64,14 +56,6 @@
             "hash": "sha256:bdf239647e18b9b9ddbc2894fd1de9786b7a9144b1d19e32a5be3bb4bb63ae5d",
             "version": "==2.1.2"
         },
-        "parse": {
-            "hash": "sha256:8b4f28bbe7c0f24981669ea92b2ba704ee63b5346027e82be30118bb5788ff10",
-            "version": "==1.8.0"
-        },
-        "parse_type": {
-            "hash": "sha256:3dd0b323bafcb8c25e000ce5589042a1c99cba9c3bec77b9f591e46bc9606147",
-            "version": "==0.3.4"
-        },
         "pyasn1": {
             "hash": "sha256:0439b9bd518418260c2641a571f0e07fce4370cab13b68f19b5e023306c03cad",
             "version": "==0.2.3"
@@ -88,10 +72,6 @@
             "hash": "sha256:fee43f17a9c4087e7ed1605bd6df994c6173c1e977d7ade7b651292fab2bd010",
             "version": "==2.2.0"
         },
-        "requests": {
-            "hash": "sha256:1a720e8862a41aa22e339373b526f508ef0c8988baf48b84d3fc891a8e237efb",
-            "version": "==2.13.0"
-        },
         "setuptools": {
             "hash": "sha256:6483f8412313ec787fa71379147a4605d3b1cc303c3648d02542a9160d3db72b",
             "version": "==34.3.2"
@@ -102,9 +82,21 @@
         }
     },
     "develop": {
+        "PyHamcrest": {
+            "hash": "sha256:6b672c02fdf7470df9674ab82263841ce8333fb143f32f021f6cb26f0e512420",
+            "version": "==1.9.0"
+        },
+        "appdirs": {
+            "hash": "sha256:d8b24664561d0d34ddfaec54636d502d7cea6e29c3eaf68f3df6180863e2166e",
+            "version": "==1.4.3"
+        },
         "astroid": {
             "hash": "sha256:944400d94e45865af150fb98700b27b788ddee5ad17c77d0725f67ac271f7a10",
             "version": "==1.4.9"
+        },
+        "behave": {
+            "hash": "sha256:89238a5e4b11ff607e8ebc6b4b1fb1a0b1f3d794fba80e1fb4b6b3652979c927",
+            "version": "==1.2.5"
         },
         "isort": {
             "hash": "sha256:a0c38c1c5e4c70ea1141daa80c740372ad94351e92e9e07da1cd86ce65653dc4",
@@ -118,9 +110,33 @@
             "hash": "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42",
             "version": "==0.6.1"
         },
+        "packaging": {
+            "hash": "sha256:99276dc6e3a7851f32027a68f1095cd3f77c148091b092ea867a351811cfe388",
+            "version": "==16.8"
+        },
+        "parse": {
+            "hash": "sha256:8b4f28bbe7c0f24981669ea92b2ba704ee63b5346027e82be30118bb5788ff10",
+            "version": "==1.8.0"
+        },
+        "parse_type": {
+            "hash": "sha256:3dd0b323bafcb8c25e000ce5589042a1c99cba9c3bec77b9f591e46bc9606147",
+            "version": "==0.3.4"
+        },
         "pylint": {
             "hash": "sha256:c15405aa2a8b982c059ad7e76effe7c7531490af08890a2fcb0c64c9e25b70f9",
             "version": "==1.6.5"
+        },
+        "pyparsing": {
+            "hash": "sha256:fee43f17a9c4087e7ed1605bd6df994c6173c1e977d7ade7b651292fab2bd010",
+            "version": "==2.2.0"
+        },
+        "requests": {
+            "hash": "sha256:1a720e8862a41aa22e339373b526f508ef0c8988baf48b84d3fc891a8e237efb",
+            "version": "==2.13.0"
+        },
+        "setuptools": {
+            "hash": "sha256:6483f8412313ec787fa71379147a4605d3b1cc303c3648d02542a9160d3db72b",
+            "version": "==34.3.2"
         },
         "six": {
             "hash": "sha256:0ff78c403d9bccf5a425a6d31a12aa6b47f1c21ca4dc2573a7e2f32a97335eb1",

--- a/README.md
+++ b/README.md
@@ -11,9 +11,12 @@ their own.
 
 ## Migration prototype
 
-The migration prototype currently handles exactly one case:
-migrating from a CentOS 7 VM to a macrocontainer running on
-a CentOS 7 container host.
+The migration prototype currently handles exactly two cases:
+
+* migrating from a CentOS 6 VM to a macrocontainer running on
+  a CentOS 7 container host.
+* migrating from a CentOS 7 VM to a macrocontainer running on
+  a CentOS 7 container host.
 
 ### Setting up to run the prototype demonstration
 
@@ -100,7 +103,11 @@ Known Constraints
 
 Currently known constraints on this approach:
 
-* Migration currently only works for source VMs using
-  systemd as their init system
 * SELinux process separation is not available inside
   the resulting macrocontainer
+
+
+Key limitations in the current implementation:
+
+* Remote access to systems requires known Vagrant
+  managed VMs running locally under libvirt

--- a/integration-tests/.gitignore
+++ b/integration-tests/.gitignore
@@ -1,0 +1,2 @@
+# Symlink to virtualenv
+.venv

--- a/integration-tests/Pipfile
+++ b/integration-tests/Pipfile
@@ -2,6 +2,11 @@
 url = "https://pypi.python.org/simple"
 verify_ssl = true
 
+[dev-packages]
+pylint = "*"
+
 [packages]
 behave = "*"
 ansible = ">= 2.0"
+requests = "*"
+PyHamcrest = "*"

--- a/integration-tests/Pipfile
+++ b/integration-tests/Pipfile
@@ -1,0 +1,7 @@
+[[source]]
+url = "https://pypi.python.org/simple"
+verify_ssl = true
+
+[packages]
+behave = "*"
+ansible = ">= 2.0"

--- a/integration-tests/Pipfile.lock
+++ b/integration-tests/Pipfile.lock
@@ -1,0 +1,105 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "ee4bf67c6306b8a8db27450d5f809ffd2f37db79fcea2caa81641ffeb60a9a89"
+        },
+        "requires": {},
+        "sources": [
+            {
+                "url": "https://pypi.python.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "Jinja2": {
+            "hash": "sha256:3997cf273f1424207c60d5895264f74483fce72702f15a7cd51a8551d43663ca",
+            "version": "==2.8.1"
+        },
+        "MarkupSafe": {
+            "hash": "sha256:a6be69091dac236ea9c6bc7d012beab42010fa914c459791d627dad4910eb665",
+            "version": "==1.0"
+        },
+        "PyYAML": {
+            "hash": "sha256:592766c6303207a20efc445587778322d7f73b161bd994f227adaa341ba212ab",
+            "version": "==3.12"
+        },
+        "ansible": {
+            "hash": "sha256:63a12ea784c0f90e43293b973d5c75263634c7415e463352846cd676c188e93f",
+            "version": "==2.2.1.0"
+        },
+        "appdirs": {
+            "hash": "sha256:d8b24664561d0d34ddfaec54636d502d7cea6e29c3eaf68f3df6180863e2166e",
+            "version": "==1.4.3"
+        },
+        "asn1crypto": {
+            "hash": "sha256:d232509fefcfcdb9a331f37e9c9dc20441019ad927c7d2176cf18ed5da0ba097",
+            "version": "==0.22.0"
+        },
+        "behave": {
+            "hash": "sha256:89238a5e4b11ff607e8ebc6b4b1fb1a0b1f3d794fba80e1fb4b6b3652979c927",
+            "version": "==1.2.5"
+        },
+        "cffi": {
+            "hash": "sha256:9163f7743cf9991edaddf9cf886708e288fab38e1b9fec9c41c15c85c8f7f147",
+            "version": "==1.9.1"
+        },
+        "cryptography": {
+            "hash": "sha256:323524312bb467565ebca7e50c8ae5e9674e544951d28a2904a50012a8828190",
+            "version": "==1.8.1"
+        },
+        "enum34": {
+            "hash": "sha256:6bd0f6ad48ec2aa117d3d141940d484deccda84d4fcd884f5c3d93c23ecd8c79",
+            "version": "==1.1.6"
+        },
+        "idna": {
+            "hash": "sha256:cc19709fd6d0cbfed39ea875d29ba6d4e22c0cebc510a76d6302a28385e8bb70",
+            "version": "==2.5"
+        },
+        "ipaddress": {
+            "hash": "sha256:d34cf15d95ce9a734560f7400a8bd2ac2606f378e2a1d0eadbf1c98707e7c74a",
+            "version": "==1.0.18"
+        },
+        "packaging": {
+            "hash": "sha256:99276dc6e3a7851f32027a68f1095cd3f77c148091b092ea867a351811cfe388",
+            "version": "==16.8"
+        },
+        "paramiko": {
+            "hash": "sha256:bdf239647e18b9b9ddbc2894fd1de9786b7a9144b1d19e32a5be3bb4bb63ae5d",
+            "version": "==2.1.2"
+        },
+        "parse": {
+            "hash": "sha256:8b4f28bbe7c0f24981669ea92b2ba704ee63b5346027e82be30118bb5788ff10",
+            "version": "==1.8.0"
+        },
+        "parse_type": {
+            "hash": "sha256:3dd0b323bafcb8c25e000ce5589042a1c99cba9c3bec77b9f591e46bc9606147",
+            "version": "==0.3.4"
+        },
+        "pyasn1": {
+            "hash": "sha256:0439b9bd518418260c2641a571f0e07fce4370cab13b68f19b5e023306c03cad",
+            "version": "==0.2.3"
+        },
+        "pycparser": {
+            "hash": "sha256:0aac31e917c24cb3357f5a4d5566f2cc91a19ca41862f6c3c22dc60a629673b6",
+            "version": "==2.17"
+        },
+        "pycrypto": {
+            "hash": "sha256:f2ce1e989b272cfcb677616763e0a2e7ec659effa67a88aa92b3a65528f60a3c",
+            "version": "==2.6.1"
+        },
+        "pyparsing": {
+            "hash": "sha256:fee43f17a9c4087e7ed1605bd6df994c6173c1e977d7ade7b651292fab2bd010",
+            "version": "==2.2.0"
+        },
+        "setuptools": {
+            "hash": "sha256:6483f8412313ec787fa71379147a4605d3b1cc303c3648d02542a9160d3db72b",
+            "version": "==34.3.2"
+        },
+        "six": {
+            "hash": "sha256:0ff78c403d9bccf5a425a6d31a12aa6b47f1c21ca4dc2573a7e2f32a97335eb1",
+            "version": "==1.10.0"
+        }
+    },
+    "develop": {}
+}

--- a/integration-tests/Pipfile.lock
+++ b/integration-tests/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "ee4bf67c6306b8a8db27450d5f809ffd2f37db79fcea2caa81641ffeb60a9a89"
+            "sha256": "4713f05e1b1892646f7ae415a98708f0dafb1db5d9ceeeab65f0734a2a0b4f97"
         },
         "requires": {},
         "sources": [
@@ -19,6 +19,10 @@
         "MarkupSafe": {
             "hash": "sha256:a6be69091dac236ea9c6bc7d012beab42010fa914c459791d627dad4910eb665",
             "version": "==1.0"
+        },
+        "PyHamcrest": {
+            "hash": "sha256:6b672c02fdf7470df9674ab82263841ce8333fb143f32f021f6cb26f0e512420",
+            "version": "==1.9.0"
         },
         "PyYAML": {
             "hash": "sha256:592766c6303207a20efc445587778322d7f73b161bd994f227adaa341ba212ab",
@@ -41,24 +45,16 @@
             "version": "==1.2.5"
         },
         "cffi": {
-            "hash": "sha256:9163f7743cf9991edaddf9cf886708e288fab38e1b9fec9c41c15c85c8f7f147",
+            "hash": "sha256:a7930e73a4359b52323d09de6d6860840314aa09346cbcf4def8875e1b07ebc7",
             "version": "==1.9.1"
         },
         "cryptography": {
             "hash": "sha256:323524312bb467565ebca7e50c8ae5e9674e544951d28a2904a50012a8828190",
             "version": "==1.8.1"
         },
-        "enum34": {
-            "hash": "sha256:6bd0f6ad48ec2aa117d3d141940d484deccda84d4fcd884f5c3d93c23ecd8c79",
-            "version": "==1.1.6"
-        },
         "idna": {
             "hash": "sha256:cc19709fd6d0cbfed39ea875d29ba6d4e22c0cebc510a76d6302a28385e8bb70",
             "version": "==2.5"
-        },
-        "ipaddress": {
-            "hash": "sha256:d34cf15d95ce9a734560f7400a8bd2ac2606f378e2a1d0eadbf1c98707e7c74a",
-            "version": "==1.0.18"
         },
         "packaging": {
             "hash": "sha256:99276dc6e3a7851f32027a68f1095cd3f77c148091b092ea867a351811cfe388",
@@ -92,6 +88,10 @@
             "hash": "sha256:fee43f17a9c4087e7ed1605bd6df994c6173c1e977d7ade7b651292fab2bd010",
             "version": "==2.2.0"
         },
+        "requests": {
+            "hash": "sha256:1a720e8862a41aa22e339373b526f508ef0c8988baf48b84d3fc891a8e237efb",
+            "version": "==2.13.0"
+        },
         "setuptools": {
             "hash": "sha256:6483f8412313ec787fa71379147a4605d3b1cc303c3648d02542a9160d3db72b",
             "version": "==34.3.2"
@@ -101,5 +101,34 @@
             "version": "==1.10.0"
         }
     },
-    "develop": {}
+    "develop": {
+        "astroid": {
+            "hash": "sha256:944400d94e45865af150fb98700b27b788ddee5ad17c77d0725f67ac271f7a10",
+            "version": "==1.4.9"
+        },
+        "isort": {
+            "hash": "sha256:a0c38c1c5e4c70ea1141daa80c740372ad94351e92e9e07da1cd86ce65653dc4",
+            "version": "==4.2.5"
+        },
+        "lazy-object-proxy": {
+            "hash": "sha256:b83adc06c46039018b4b47ef2a5677006e899a52be16ff57df6229cd89d6a53b",
+            "version": "==1.2.2"
+        },
+        "mccabe": {
+            "hash": "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42",
+            "version": "==0.6.1"
+        },
+        "pylint": {
+            "hash": "sha256:c15405aa2a8b982c059ad7e76effe7c7531490af08890a2fcb0c64c9e25b70f9",
+            "version": "==1.6.5"
+        },
+        "six": {
+            "hash": "sha256:0ff78c403d9bccf5a425a6d31a12aa6b47f1c21ca4dc2573a7e2f32a97335eb1",
+            "version": "==1.10.0"
+        },
+        "wrapt": {
+            "hash": "sha256:42160c91b77f1bc64a955890038e02f2f72986c01d462d53cb6cb039b995cdd9",
+            "version": "==1.10.10"
+        }
+    }
 }

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -43,7 +43,8 @@ To get a local shell with the testing environment active, run:
     $ pipenv shell
 
 Once in the testing environment, the tests can be run by invoking
-`behave` test runner directly:
+`behave` test runner directly from the `integration-tests`
+directory:
 
     $ behave
 

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -13,6 +13,10 @@ of kernel modernization attempts given different starting scenarios.
 
 ## Setting up
 
+Install `vagrant` and `vagrant-libvirt`:
+
+    $ sudo dnf install vagrant vagrant-libvirt
+
 Install `pipenv` and the `pew` environment management tool:
 
     $ pip install --user pipsi
@@ -27,17 +31,31 @@ so `pipenv` sees only the command line interface instead of the Python API)
 Once `pipenv` is installed, run the following to install the
 integration testing environment:
 
-    $ pipenv install
+    $ pipenv --three && pipenv install
+
+Note that while `leapp` itself will run under Python 2.7, the integration
+tests require Python 3.
 
 ## Running the tests
-
-Once the environment is set up, the tests can be run via:
-
-    $ pipenv run behave
 
 To get a local shell with the testing environment active, run:
 
     $ pipenv shell
 
-Once in the testing environment, the tests can be run just by
-invoking `behave` directly.
+Once in the testing environment, the tests can be run by invoking
+`behave` test runner directly:
+
+    $ behave
+
+The tests require passwordless `sudo` access to both `vagrant`
+and `leapp-tool` (alternatively, they will require interactive
+password entry during the test).
+
+## Writing new tests
+
+New feature definitions go in the ["features"](./features) subdirectory.
+
+New step definitions go in the ["features/steps"](./features.steps)
+subdirectory, and use the
+["hamcrest"](https://pyhamcrest.readthedocs.io/en/latest/tutorial/)
+library to define behavioural expectations.

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -1,0 +1,43 @@
+# Kernel modernization integration tests
+
+This directory contains integration tests that check the expected results
+of kernel modernization attempts given different starting scenarios.
+
+* Test scenarios and expectations are defined using the Python
+  [behave](http://pythonhosted.org/behave/) framework
+* Local virtual machines for test cases are defined and configured
+  using the
+  [Ansible Python API](http://docs.ansible.com/ansible/dev_guide/developing_api.html)
+* The integration testing environment itself is configured using
+  [pipenv](https://pypi.python.org/pypi/pipenv)
+
+## Setting up
+
+Install `pipenv` and the `pew` environment management tool:
+
+    $ pip install --user pipsi
+    $ pipsi install pew
+    $ pipsi install pipenv
+
+The above commands do a user level install of the "pip script installer",
+and then install `pew` and `pipenv` into isolated virtual environments
+for reliability of later updates. (`pew` needs to be installed separately
+so `pipenv` sees only the command line interface instead of the Python API)
+
+Once `pipenv` is installed, run the following to install the
+integration testing environment:
+
+    $ pipenv install
+
+## Running the tests
+
+Once the environment is set up, the tests can be run via:
+
+    $ pipenv run behave
+
+To get a local shell with the testing environment active, run:
+
+    $ pipenv shell
+
+Once in the testing environment, the tests can be run just by
+invoking `behave` directly.

--- a/integration-tests/features/environment.py
+++ b/integration-tests/features/environment.py
@@ -1,2 +1,7 @@
+import contextlib
+
+def before_scenario(context, scenario):
+    context.resource_manager = contextlib.ExitStack()
+
 def after_scenario(context, scenario):
-    print("TODO: clean up VMs created for scenario")
+    context.resource_manager.close()

--- a/integration-tests/features/environment.py
+++ b/integration-tests/features/environment.py
@@ -1,0 +1,2 @@
+def after_scenario(context, scenario):
+    print("TODO: clean up VMs created for scenario")

--- a/integration-tests/features/httpd-stateless.feature
+++ b/integration-tests/features/httpd-stateless.feature
@@ -6,4 +6,4 @@ Scenario: HTTP default server page
          | app-source | centos6-guest-httpd | no           |
          | target     | centos7-target      | no           |
     When app-source is redeployed to target as a macrocontainer
-    Then the HTTP responses on port 80 should match within 90 seconds
+    Then the HTTP response on port 80 should match within 90 seconds

--- a/integration-tests/features/httpd-stateless.feature
+++ b/integration-tests/features/httpd-stateless.feature
@@ -1,0 +1,9 @@
+Feature: Redeploy stateless HTTP services
+
+Scenario: HTTP default server page
+   Given the local virtual machines:
+         | name       | image               | playbook |
+         | app-source | centos6-guest-httpd |          |
+         | target     | centos7-target      |          |
+    When app-source is redeployed to target as a macrocontainer
+    Then the HTTP responses on port 80 should match

--- a/integration-tests/features/httpd-stateless.feature
+++ b/integration-tests/features/httpd-stateless.feature
@@ -6,4 +6,4 @@ Scenario: HTTP default server page
          | app-source | centos6-guest-httpd | no           |
          | target     | centos7-target      | no           |
     When app-source is redeployed to target as a macrocontainer
-    Then the HTTP response on port 80 should match within 90 seconds
+    Then the HTTP 403 response on port 80 should match within 90 seconds

--- a/integration-tests/features/httpd-stateless.feature
+++ b/integration-tests/features/httpd-stateless.feature
@@ -2,8 +2,8 @@ Feature: Redeploy stateless HTTP services
 
 Scenario: HTTP default server page
    Given the local virtual machines:
-         | name       | image               | playbook |
-         | app-source | centos6-guest-httpd |          |
-         | target     | centos7-target      |          |
+         | name       | definition          | ensure_fresh |
+         | app-source | centos6-guest-httpd | no           |
+         | target     | centos7-target      | yes          |
     When app-source is redeployed to target as a macrocontainer
     Then the HTTP responses on port 80 should match

--- a/integration-tests/features/httpd-stateless.feature
+++ b/integration-tests/features/httpd-stateless.feature
@@ -6,4 +6,4 @@ Scenario: HTTP default server page
          | app-source | centos6-guest-httpd | no           |
          | target     | centos7-target      | no           |
     When app-source is redeployed to target as a macrocontainer
-    Then the HTTP responses on port 80 should match
+    Then the HTTP responses on port 80 should match within 90 seconds

--- a/integration-tests/features/httpd-stateless.feature
+++ b/integration-tests/features/httpd-stateless.feature
@@ -4,6 +4,6 @@ Scenario: HTTP default server page
    Given the local virtual machines:
          | name       | definition          | ensure_fresh |
          | app-source | centos6-guest-httpd | no           |
-         | target     | centos7-target      | yes          |
+         | target     | centos7-target      | no           |
     When app-source is redeployed to target as a macrocontainer
     Then the HTTP responses on port 80 should match

--- a/integration-tests/features/steps/common.py
+++ b/integration-tests/features/steps/common.py
@@ -1,26 +1,147 @@
 from behave import given, when, then
+from hamcrest import assert_that, equal_to, not_none
+
+import json
+import pathlib
+import subprocess
+import requests
+
+_TEST_DIR = pathlib.Path(__file__).parent.parent.parent
+_REPO_DIR = _TEST_DIR.parent
+_VM_DEFS = {path.name: str(path) for path in (_TEST_DIR / "vmdefs").iterdir()}
+_LEAPP_TOOL = str(_REPO_DIR / "leapp-tool.py")
+
+
+# Command execution helper
+def _run_command(cmd, work_dir, ignore_errors):
+    output = None
+    try:
+        output = subprocess.check_output(
+            cmd, cwd=work_dir, stderr=subprocess.PIPE
+        ).decode()
+    except subprocess.CalledProcessError as exc:
+        if not ignore_errors:
+            print(exc.stderr.decode())
+            raise
+        output = exc.output.decode()
+    return output
+
+##############################
+# Local VM management
+##############################
+
+def _run_vagrant(vm_def, *args, ignore_errors=False):
+    # TODO: explore https://pypi.python.org/pypi/python-vagrant
+    #       That may require sudo-less access to vagrant
+    vm_dir = _VM_DEFS[vm_def]
+    cmd = ["sudo", "vagrant"]
+    cmd.extend(args)
+    return _run_command(cmd, vm_dir, ignore_errors)
+
+def _vm_up(vm_def):
+    result = _run_vagrant(vm_def, "up")
+    print("Started {} VM instance".format(vm_def))
+    return result
+
+def _vm_down(vm_def):
+    result = _run_vagrant(vm_def, "down", ignore_errors=True)
+    print("Suspended {} VM instance".format(vm_def))
+    return result
+
+def _vm_destroy(vm_def):
+    result = _run_vagrant(vm_def, "destroy", ignore_errors=True)
+    print("Destroyed {} VM instance".format(vm_def))
+    return result
+
 
 @given("the local virtual machines")
 def create_local_machines(context):
     context.machines = machines = {}
-    for vm_name, image_name, playbook in context.table:
-        msg = "TODO: create VM instance from {} and register as {}"
-        print(msg.format(image_name, vm_name))
-        machines[vm_name] = image_name
+    for row in context.table:
+        vm_name = row["name"]
+        vm_def = row["definition"]
+        if vm_def not in _VM_DEFS:
+            raise ValueError("Unknown VM image: {}".format(vm_def))
+        ensure_fresh = (row["ensure_fresh"].lower() == "yes")
+        if ensure_fresh:
+            _vm_destroy(vm_def)
+        _vm_up(vm_def)
+        if ensure_fresh:
+            context.resource_manager.callback(_vm_destroy, vm_def)
+        else:
+            context.resource_manager.callback(_vm_down, vm_def)
+        machines[vm_name] = vm_def
+
+
+##############################
+# Leapp commands
+##############################
+
+def _run_leapp(*args):
+    cmd = ["sudo", "/usr/bin/python2", _LEAPP_TOOL]
+    cmd.extend(args)
+    # Using _REPO_DIR as work_dir is a kludge to enable
+    # the existing SSH kludge in leapp-tool itself,
+    # which in turn relies on the tool only being used
+    # with particular predefined Vagrant configurations
+    return _run_command(cmd, work_dir=str(_REPO_DIR), ignore_errors=False)
+
+def _convert_vm_to_macrocontainer(source_def, target_def):
+    result = _run_leapp("migrate-machine", "-t", target_def, source_def)
+    msg = "Redeployed {} as macrocontainer on {}"
+    print(msg.format(source_def, target_def))
+    return result
+
+def _get_leapp_ip(machine):
+    raw_ip = machine["ip"][0]
+    if raw_ip.startswith("ipv4-"):
+        return raw_ip[5:]
+    return raw_ip
+
+def _get_ip_addresses(source_def, target_def):
+    leapp_output = _run_leapp("list-machines", "--shallow")
+    machine_info = json.loads(leapp_output)
+    source_ip = target_ip = None
+    for machine in machine_info["machines"]:
+        if machine["name"] == source_def:
+            source_ip = _get_leapp_ip(machine)
+        if machine["name"] == target_def:
+            target_ip = _get_leapp_ip(machine)
+        if source_ip is not None and target_ip is not None:
+            break
+    return source_ip, target_ip
 
 @when("{source_vm} is redeployed to {target_vm} as a macrocontainer")
 def redeploy_vm_as_macrocontainer(context, source_vm, target_vm):
     context.redeployment_source = source_vm
     context.redeployment_target = target_vm
     machines = context.machines
-    source_info = machines[source_vm]
-    target_info = machines[target_vm]
-    msg = "TODO: redeploy {} as macrocontainer on {}"
-    print(msg.format(source_vm, target_vm))
+    source_def = machines[source_vm]
+    target_def = machines[target_vm]
+    _convert_vm_to_macrocontainer(source_def, target_def)
+    source_ip, target_ip = _get_ip_addresses(source_def, target_def)
+    context.redeployment_source_ip = source_ip
+    context.redeployment_target_ip = target_ip
+
+
+##############################
+# Service status checking
+##############################
+def _compare_responses(original_ip, redeployed_ip, *, tcp_port, status):
+    original_url = "http://{}:{}".format(original_ip, tcp_port)
+    original_response = requests.get(original_url)
+    assert_that(original_response.status, status, "Original status")
+    redeployed_url = "http://{}:{}".format(redeployed_ip, tcp_port)
+    redeployed_response = requests.get(redeployed_response)
+    assert_that(redeployed_response.status, status, "Redeployed status")
+    original_data = original_response.body
+    redeployed_data = redeployed_response.body
+    assert_that(redeployed_data, equal_to(original_body), "Same response")
 
 @then("the HTTP responses on port {tcp_port} should match")
 def check_http_responses_match(context, tcp_port):
-    msg = "TODO: get HTTP response from {}:{}"
-    print(msg.format(context.redeployment_source, tcp_port))
-    print(msg.format(context.redeployment_target, tcp_port))
-    print("TODO: Check responses match")
+    original_ip = context.redeployment_source_ip
+    assert_that(original_ip, not_none(), "Valid original IP")
+    redeployed_ip = context.redeployment_target_ip
+    assert_that(redeployed_ip, not_none(), "Valid redeployment IP")
+    _compare_responses(original_ip, redeployed_ip, tcp_port=80, status=200)

--- a/integration-tests/features/steps/common.py
+++ b/integration-tests/features/steps/common.py
@@ -1,0 +1,26 @@
+from behave import given, when, then
+
+@given("the local virtual machines")
+def create_local_machines(context):
+    context.machines = machines = {}
+    for vm_name, image_name, playbook in context.table:
+        msg = "TODO: create VM instance from {} and register as {}"
+        print(msg.format(image_name, vm_name))
+        machines[vm_name] = image_name
+
+@when("{source_vm} is redeployed to {target_vm} as a macrocontainer")
+def redeploy_vm_as_macrocontainer(context, source_vm, target_vm):
+    context.redeployment_source = source_vm
+    context.redeployment_target = target_vm
+    machines = context.machines
+    source_info = machines[source_vm]
+    target_info = machines[target_vm]
+    msg = "TODO: redeploy {} as macrocontainer on {}"
+    print(msg.format(source_vm, target_vm))
+
+@then("the HTTP responses on port {tcp_port} should match")
+def check_http_responses_match(context, tcp_port):
+    msg = "TODO: get HTTP response from {}:{}"
+    print(msg.format(context.redeployment_source, tcp_port))
+    print(msg.format(context.redeployment_target, tcp_port))
+    print("TODO: Check responses match")

--- a/integration-tests/features/steps/common.py
+++ b/integration-tests/features/steps/common.py
@@ -70,8 +70,10 @@ def create_local_machines(context):
             raise ValueError("Unknown VM image: {}".format(vm_def))
         ensure_fresh = (row["ensure_fresh"].lower() == "yes")
         if ensure_fresh:
-            # TODO: Look at using "provision" for fresh VMs
+            # TODO: Look at using "--provision" for fresh VMs
             #       Rather than a full destroy/recreate cycle
+            #       Alternatively: add "reprovision" as a
+            #       third state for the field
             _vm_destroy(vm_def)
         _vm_up(vm_def)
         if ensure_fresh:
@@ -177,7 +179,7 @@ def _compare_responses(original_ip, redeployed_ip, *,
     redeployed_data = redeployed_response.text
     assert_that(redeployed_data, equal_to(original_data), "Same response")
 
-@then("the HTTP responses on port {tcp_port} should match within {wait_duration:g} seconds")
+@then("the HTTP response on port {tcp_port} should match within {wait_duration:g} seconds")
 def check_http_responses_match(context, tcp_port, wait_duration=None):
     original_ip = context.redeployment_source_ip
     redeployed_ip = context.redeployment_target_ip

--- a/integration-tests/features/steps/common.py
+++ b/integration-tests/features/steps/common.py
@@ -161,14 +161,13 @@ def _get_target_response(redeployed_url, wait_for_target):
     raise AssertionError(fail_msg)
 
 def _compare_responses(original_ip, redeployed_ip, *,
-                       tcp_port, status=None, wait_for_target=None):
+                       tcp_port, status, wait_for_target):
     # Get response from source VM
     original_url = "http://{}:{}".format(original_ip, tcp_port)
     original_response = requests.get(original_url)
     print("Response received from {}".format(original_url))
     original_status = original_response.status_code
-    if status is not None:
-        assert_that(original_status, equal_to(status), "Original status")
+    assert_that(original_status, equal_to(status), "Original status")
     # Get response from target VM
     redeployed_url = "http://{}:{}".format(redeployed_ip, tcp_port)
     redeployed_response = _get_target_response(redeployed_url, wait_for_target)
@@ -179,8 +178,8 @@ def _compare_responses(original_ip, redeployed_ip, *,
     redeployed_data = redeployed_response.text
     assert_that(redeployed_data, equal_to(original_data), "Same response")
 
-@then("the HTTP response on port {tcp_port} should match within {wait_duration:g} seconds")
-def check_http_responses_match(context, tcp_port, wait_duration=None):
+@then("the HTTP {status:d} response on port {tcp_port} should match within {wait_duration:g} seconds")
+def check_http_responses_match(context, tcp_port, status, wait_duration):
     original_ip = context.redeployment_source_ip
     redeployed_ip = context.redeployment_target_ip
     assert_that(original_ip, not_none(), "Valid original IP")
@@ -188,5 +187,6 @@ def check_http_responses_match(context, tcp_port, wait_duration=None):
     _compare_responses(
         original_ip, redeployed_ip,
         tcp_port=tcp_port,
+        status=status,
         wait_for_target=wait_duration
     )

--- a/integration-tests/features/steps/common.py
+++ b/integration-tests/features/steps/common.py
@@ -1,16 +1,21 @@
-from behave import given, when, then
+from behave import given, when, then, step
 from hamcrest import assert_that, equal_to, not_none, greater_than
 
 import json
 import pathlib
-import subprocess
 import requests
+import subprocess
+import time
 
 _TEST_DIR = pathlib.Path(__file__).parent.parent.parent
 _REPO_DIR = _TEST_DIR.parent
 _VM_DEFS = {path.name: str(path) for path in (_TEST_DIR / "vmdefs").iterdir()}
 _LEAPP_TOOL = str(_REPO_DIR / "leapp-tool.py")
 
+
+##############################
+# General utilities
+##############################
 
 # Command execution helper
 def _run_command(cmd, work_dir, ignore_errors):
@@ -136,23 +141,50 @@ def redeploy_vm_as_macrocontainer(context, source_vm, target_vm):
 ##############################
 # Service status checking
 ##############################
-def _compare_responses(original_ip, redeployed_ip, *, tcp_port, status):
+
+def _get_target_response(redeployed_url, wait_for_target):
+    deadline = time.monotonic()
+    if wait_for_target is None:
+        fail_msg = "No response from target"
+    else:
+        fail_msg = "No response from target within {} seconds".format(wait_for_target)
+        deadline += wait_for_target
+    while True:
+        try:
+            return requests.get(redeployed_url)
+        except Exception:
+            pass
+        if time.monotonic() >= deadline:
+            break
+    raise AssertionError(fail_msg)
+
+def _compare_responses(original_ip, redeployed_ip, *,
+                       tcp_port, status=None, wait_for_target=None):
+    # Get response from source VM
     original_url = "http://{}:{}".format(original_ip, tcp_port)
     original_response = requests.get(original_url)
     print("Response received from {}".format(original_url))
-    assert_that(original_response.status_code, status, "Original status")
+    original_status = original_response.status_code
+    if status is not None:
+        assert_that(original_status, equal_to(status), "Original status")
+    # Get response from target VM
     redeployed_url = "http://{}:{}".format(redeployed_ip, tcp_port)
-    redeployed_response = requests.get(redeployed_url)
+    redeployed_response = _get_target_response(redeployed_url, wait_for_target)
     print("Response received from {}".format(redeployed_url))
-    assert_that(redeployed_response.status_code, status, "Redeployed status")
-    original_data = original_response.body
-    redeployed_data = redeployed_response.body
+    # Compare the responses
+    assert_that(redeployed_response.status_code, equal_to(original_status), "Redeployed status")
+    original_data = original_response.text
+    redeployed_data = redeployed_response.text
     assert_that(redeployed_data, equal_to(original_data), "Same response")
 
-@then("the HTTP responses on port {tcp_port} should match")
-def check_http_responses_match(context, tcp_port):
+@then("the HTTP responses on port {tcp_port} should match within {wait_duration:g} seconds")
+def check_http_responses_match(context, tcp_port, wait_duration=None):
     original_ip = context.redeployment_source_ip
     redeployed_ip = context.redeployment_target_ip
     assert_that(original_ip, not_none(), "Valid original IP")
     assert_that(redeployed_ip, not_none(), "Valid redeployment IP")
-    _compare_responses(original_ip, redeployed_ip, tcp_port=80, status=200)
+    _compare_responses(
+        original_ip, redeployed_ip,
+        tcp_port=tcp_port,
+        wait_for_target=wait_duration
+    )

--- a/integration-tests/vmdefs/centos6-guest-httpd/Vagrantfile
+++ b/integration-tests/vmdefs/centos6-guest-httpd/Vagrantfile
@@ -1,0 +1,23 @@
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+    config.vm.box = "centos/6"
+    config.vm.hostname = "centos6-guest-httpd"
+
+    config.vm.network :private_network, ip: "10.0.0.10"
+    config.vm.synced_folder "./", "/var/www/html", type: "rsync", id: "vagrant", :nfs => false,
+        :mount_options => ["dmode=777", "fmode=666"]
+
+    config.vm.provider :libvirt do |libvirt|
+        libvirt.memory = 1024
+        libvirt.cpus = 1
+    end
+
+    config.vm.provision "ansible" do |ansible|
+        ansible.playbook = "ansible/playbook.yml"
+        ansible.sudo = true
+    end
+
+    config.vm.provision :shell, inline: "echo Good job, now enjoy your new vbox: http://10.0.0.10"
+
+end

--- a/integration-tests/vmdefs/centos6-guest-httpd/Vagrantfile
+++ b/integration-tests/vmdefs/centos6-guest-httpd/Vagrantfile
@@ -5,8 +5,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     config.vm.hostname = "centos6-guest-httpd"
 
     config.vm.network :private_network, ip: "10.0.0.10"
-    config.vm.synced_folder "./", "/var/www/html", type: "rsync", id: "vagrant", :nfs => false,
-        :mount_options => ["dmode=777", "fmode=666"]
 
     config.vm.provider :libvirt do |libvirt|
         libvirt.memory = 1024

--- a/integration-tests/vmdefs/centos6-guest-httpd/ansible/playbook.yml
+++ b/integration-tests/vmdefs/centos6-guest-httpd/ansible/playbook.yml
@@ -1,0 +1,7 @@
+# file: ansible/playbook.yml
+---
+ - hosts: all
+
+   roles:
+    - init
+    - httpd

--- a/integration-tests/vmdefs/centos6-guest-httpd/ansible/roles/httpd/defaults/main.yml
+++ b/integration-tests/vmdefs/centos6-guest-httpd/ansible/roles/httpd/defaults/main.yml
@@ -1,0 +1,6 @@
+# file: roles/httpd/defaults/main.yml
+---
+
+# used in apache vhost configuration files
+doc_root: /var/www/html
+hostname: vagrantbox

--- a/integration-tests/vmdefs/centos6-guest-httpd/ansible/roles/httpd/handlers/main.yml
+++ b/integration-tests/vmdefs/centos6-guest-httpd/ansible/roles/httpd/handlers/main.yml
@@ -1,0 +1,5 @@
+# file: roles/httpd/handlers/main.yml
+---
+
+- name: restart httpd
+  service: name=httpd state=restarted

--- a/integration-tests/vmdefs/centos6-guest-httpd/ansible/roles/httpd/tasks/configure.yml
+++ b/integration-tests/vmdefs/centos6-guest-httpd/ansible/roles/httpd/tasks/configure.yml
@@ -6,7 +6,7 @@
 - name: Set global ServerName for apache config
   lineinfile: dest=/etc/httpd/conf/httpd.conf line="ServerName localhost"
 
-- name: SELinux to enforcing
+- name: SELinux to permissive
   command: setenforce 0
   notify:
     - restart httpd

--- a/integration-tests/vmdefs/centos6-guest-httpd/ansible/roles/httpd/tasks/configure.yml
+++ b/integration-tests/vmdefs/centos6-guest-httpd/ansible/roles/httpd/tasks/configure.yml
@@ -1,0 +1,15 @@
+# file: roles/httpd/tasks/configure.yml
+
+- name: Change default apache vhost
+  template: src=default.tpl dest=/etc/httpd/conf.d/000-default.conf
+
+- name: Set global ServerName for apache config
+  lineinfile: dest=/etc/httpd/conf/httpd.conf line="ServerName localhost"
+
+- name: SELinux to enforcing
+  command: setenforce 0
+  notify:
+    - restart httpd
+
+- name: Ensure Apache running
+  service: name=httpd state=started enabled=yes

--- a/integration-tests/vmdefs/centos6-guest-httpd/ansible/roles/httpd/tasks/install.yml
+++ b/integration-tests/vmdefs/centos6-guest-httpd/ansible/roles/httpd/tasks/install.yml
@@ -1,0 +1,7 @@
+# file: roles/httpd/tasks/install.yml
+
+- name: Install Apache web server
+  yum: pkg={{ item }} state=installed
+  with_items:
+     - httpd
+     - libselinux-python

--- a/integration-tests/vmdefs/centos6-guest-httpd/ansible/roles/httpd/tasks/main.yml
+++ b/integration-tests/vmdefs/centos6-guest-httpd/ansible/roles/httpd/tasks/main.yml
@@ -1,0 +1,5 @@
+# file: roles/httpd/tasks/main.yml
+
+- include: install.yml
+- include: configure.yml
+- include: secure.yml

--- a/integration-tests/vmdefs/centos6-guest-httpd/ansible/roles/httpd/tasks/secure.yml
+++ b/integration-tests/vmdefs/centos6-guest-httpd/ansible/roles/httpd/tasks/secure.yml
@@ -1,0 +1,4 @@
+# file: roles/httpd/tasks/secure.yml
+
+- name: Flush iptables
+  shell: iptables -F

--- a/integration-tests/vmdefs/centos6-guest-httpd/ansible/roles/httpd/templates/default.tpl
+++ b/integration-tests/vmdefs/centos6-guest-httpd/ansible/roles/httpd/templates/default.tpl
@@ -1,0 +1,19 @@
+<VirtualHost *:80>
+  ServerAdmin webmaster@localhost
+  DocumentRoot {{ doc_root }}
+
+  <Directory />
+          Options Indexes FollowSymLinks Includes ExecCGI
+          AllowOverride ALL
+  </Directory>
+
+
+  <Directory {{ doc_root }}>
+    Options Indexes FollowSymLinks Includes ExecCGI
+    AllowOverride All
+    Require all granted
+  </Directory>
+
+  ErrorLog "/var/log/httpd/html-error_log"
+  CustomLog "/var/log/httpd/html-access_log" common
+</VirtualHost>

--- a/integration-tests/vmdefs/centos6-guest-httpd/ansible/roles/httpd/templates/default.tpl
+++ b/integration-tests/vmdefs/centos6-guest-httpd/ansible/roles/httpd/templates/default.tpl
@@ -11,7 +11,6 @@
   <Directory {{ doc_root }}>
     Options Indexes FollowSymLinks Includes ExecCGI
     AllowOverride All
-    Require all granted
   </Directory>
 
   ErrorLog "/var/log/httpd/html-error_log"

--- a/integration-tests/vmdefs/centos6-guest-httpd/ansible/roles/init/handlers/main.yml
+++ b/integration-tests/vmdefs/centos6-guest-httpd/ansible/roles/init/handlers/main.yml
@@ -1,0 +1,5 @@
+# file: roles/php56/handlers/main.yml
+---
+
+- name: restart iptables
+  service: name=iptables state=restarted

--- a/integration-tests/vmdefs/centos6-guest-httpd/ansible/roles/init/tasks/main.yml
+++ b/integration-tests/vmdefs/centos6-guest-httpd/ansible/roles/init/tasks/main.yml
@@ -1,0 +1,18 @@
+# file: roles/init/tasks/main.yml
+---
+
+- name: Update Yum
+  yum: name=* state=latest
+
+- name: Install nano, git, etc
+  yum: pkg={{ item }} state=installed
+  with_items:
+     - git
+     - nano
+     - curl
+     - gcc
+     - kernel-devel
+     - wget
+     - vim
+     - man
+     - unzip

--- a/integration-tests/vmdefs/centos7-target/Vagrantfile
+++ b/integration-tests/vmdefs/centos7-target/Vagrantfile
@@ -1,0 +1,20 @@
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+    config.vm.box = "centos/7"
+    config.vm.hostname = "centos7-target"
+
+    config.vm.network :private_network, ip: "10.0.0.11"
+
+    config.vm.provider :libvirt do |libvirt|
+        libvirt.memory = 1024
+        libvirt.cpus = 1
+    end
+
+    config.vm.provision "ansible" do |ansible|
+        ansible.playbook = "ansible/playbook.yml"
+        ansible.sudo = true
+    end
+
+    config.vm.provision :shell, inline: "echo Good job! Now vagrant ssh"
+end

--- a/integration-tests/vmdefs/centos7-target/ansible/playbook.yml
+++ b/integration-tests/vmdefs/centos7-target/ansible/playbook.yml
@@ -1,0 +1,6 @@
+# file: ansible/playbook.yml
+---
+ - hosts: all
+   roles:
+    - init
+    - docker

--- a/integration-tests/vmdefs/centos7-target/ansible/roles/docker/tasks/main.yml
+++ b/integration-tests/vmdefs/centos7-target/ansible/roles/docker/tasks/main.yml
@@ -1,0 +1,9 @@
+# file: roles/docker/tasks/install.yml
+
+- name: Install Docker
+  yum: pkg={{ item }} state=present
+  with_items:
+    - docker
+
+- name: Ensure Docker is enabled & running
+  service: name=docker state=started enabled=yes

--- a/integration-tests/vmdefs/centos7-target/ansible/roles/init/tasks/main.yml
+++ b/integration-tests/vmdefs/centos7-target/ansible/roles/init/tasks/main.yml
@@ -1,0 +1,8 @@
+# file: roles/init/tasks/main.yml
+---
+
+- name: Update Yum
+  yum: name=* state=latest
+
+- name: Ensure directories
+  file: path=/opt/leapp-to state=directory owner=vagrant group=vagrant

--- a/leapp-tool.py
+++ b/leapp-tool.py
@@ -9,7 +9,10 @@ from subprocess import Popen, PIPE, check_output, CalledProcessError
 
 def _get_ssh_config():
     # use vagrant ssh-config to obtain SSH configuration for the desired box
-    ssh_kludge = {'target': 'ansible/centos7-target', 'source': 'ansible/centos6-guest-lamp'}
+    ssh_kludge = {
+        'target': 'integration-tests/vmdefs/centos7-target',
+        'source': 'integration-tests/vmdefs/centos6-guest-httpd'
+    }
     out = {}
     for typ, path in ssh_kludge.iteritems():
         try:

--- a/leapp-tool.py
+++ b/leapp-tool.py
@@ -5,6 +5,7 @@ from leappto.providers.libvirt_provider import LibvirtMachineProvider
 from json import dumps
 from os import getuid
 from subprocess import Popen, PIPE, check_output, CalledProcessError
+import sys
 
 
 def _get_ssh_config():
@@ -80,7 +81,7 @@ class MigrationContext:
         good_mounts = ['bin', 'etc', 'home', 'lib', 'lib64', 'media', 'opt', 'root', 'sbin', 'srv', 'usr', 'var']
         for mount in good_mounts:
             command += ' -v /opt/leapp-to/container/{m}:/{m}:Z'.format(m=mount)
-        command += ' -p 9000:9000 -p 9022:22 --name container ' + img + ' ' + init
+        command += ' -p 80:80 -p 9022:22 --name container ' + img + ' ' + init
         return self._ssh_sudo(command)
 
     def _fix_container(self, fix_str):
@@ -114,6 +115,7 @@ elif parsed.action == 'migrate-machine':
     if not parsed.target:
         print('! no target specified, creating leappto container package in current directory')
         # TODO: not really for now
+        raise NotImplementedError
     else:
         source = parsed.machine
         target = parsed.target
@@ -142,12 +144,12 @@ elif parsed.action == 'migrate-machine':
         print('! provisioning ...')
         # if el7 then use systemd
         if machine_src.installation.os.version.startswith('7'):
-            mc.start_container('centos:7', '/usr/lib/systemd/systemd --system')
+            result = mc.start_container('centos:7', '/usr/lib/systemd/systemd --system')
             print('! starting services')
             mc.fix_systemd()
-            print('! done')
         else:
-            mc.start_container('centos:6', '/sbin/init')
+            result = mc.start_container('centos:6', '/sbin/init')
             print('! starting services')
             mc.fix_upstart()
-            print('! done')
+        print('! done')
+        sys.exit(result)

--- a/start_integration_vms.sh
+++ b/start_integration_vms.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/sh
+pushd integration-tests/vmdefs/centos6-guest-httpd/
+sudo vagrant up
+popd
+pushd integration-tests/vmdefs/centos7-target/
+sudo vagrant up
+popd


### PR DESCRIPTION
- expected behaviours defined with behave and PyHamcrest
- configures local VMs with Vagrant and Ansible
- uses Leapp to run macrocontainer redeployments
  and query local IP addreses
- uses requests to check web service behaviour
- uses pipenv to manage the test environment itself

Known issues:
* VM IP addresses are not being retrieved correctly
* relies on the SSH kludge in leapp-tool to access the VMs
* even the simple baseline scenario takes ~5 minutes to run (~200s for VM setup, ~100s for the migration)