### PR TITLE
Move test helpers to behave context

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -2,11 +2,12 @@
 url = "https://pypi.python.org/simple"
 verify_ssl = true
 
+[packages]
+ansible = ">= 2.0"
+
 [dev-packages]
 behave = "*"
 pylint = "*"
 requests = "*"
+attrs = "*"
 PyHamcrest = "*"
-
-[packages]
-ansible = ">= 2.0"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "2e44e32d168e660c33500909dad6f514aa4c5fa49fc50e802697bec5d76c59fa"
+            "sha256": "8dc64b10d88748084ec4f4c71fea6b4f053b972adc75643bea2e6a5f5a845e55"
         },
         "requires": {},
         "sources": [
@@ -13,8 +13,8 @@
     },
     "default": {
         "Jinja2": {
-            "hash": "sha256:3997cf273f1424207c60d5895264f74483fce72702f15a7cd51a8551d43663ca",
-            "version": "==2.8.1"
+            "hash": "sha256:2231bace0dfd8d2bf1e5d7e41239c06c9e0ded46e70cc1094a0aa64b0afeb054",
+            "version": "==2.9.6"
         },
         "MarkupSafe": {
             "hash": "sha256:a6be69091dac236ea9c6bc7d012beab42010fa914c459791d627dad4910eb665",
@@ -25,8 +25,8 @@
             "version": "==3.12"
         },
         "ansible": {
-            "hash": "sha256:63a12ea784c0f90e43293b973d5c75263634c7415e463352846cd676c188e93f",
-            "version": "==2.2.1.0"
+            "hash": "sha256:efd9c574168ac1916dd57f7c88d4dd2e13ef816af0ee49a8d34c77567886e4c2",
+            "version": "==2.2.2.0"
         },
         "appdirs": {
             "hash": "sha256:d8b24664561d0d34ddfaec54636d502d7cea6e29c3eaf68f3df6180863e2166e",
@@ -73,8 +73,8 @@
             "version": "==2.2.0"
         },
         "setuptools": {
-            "hash": "sha256:6483f8412313ec787fa71379147a4605d3b1cc303c3648d02542a9160d3db72b",
-            "version": "==34.3.2"
+            "hash": "sha256:e436d8c9dcf67ea8902bfa7cce1ef698f36bf303f13b4f62a5668891ecd380dd",
+            "version": "==34.3.3"
         },
         "six": {
             "hash": "sha256:0ff78c403d9bccf5a425a6d31a12aa6b47f1c21ca4dc2573a7e2f32a97335eb1",
@@ -93,6 +93,10 @@
         "astroid": {
             "hash": "sha256:944400d94e45865af150fb98700b27b788ddee5ad17c77d0725f67ac271f7a10",
             "version": "==1.4.9"
+        },
+        "attrs": {
+            "hash": "sha256:c59426b15b45e39a7bc408eb6ba7e7188d9532764f873cc691199ddd975c97ef",
+            "version": "==16.3.0"
         },
         "behave": {
             "hash": "sha256:89238a5e4b11ff607e8ebc6b4b1fb1a0b1f3d794fba80e1fb4b6b3652979c927",
@@ -135,8 +139,8 @@
             "version": "==2.13.0"
         },
         "setuptools": {
-            "hash": "sha256:6483f8412313ec787fa71379147a4605d3b1cc303c3648d02542a9160d3db72b",
-            "version": "==34.3.2"
+            "hash": "sha256:e436d8c9dcf67ea8902bfa7cce1ef698f36bf303f13b4f62a5668891ecd380dd",
+            "version": "==34.3.3"
         },
         "six": {
             "hash": "sha256:0ff78c403d9bccf5a425a6d31a12aa6b47f1c21ca4dc2573a7e2f32a97335eb1",

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -64,10 +64,27 @@ password entry during the test).
 
 New feature definitions go in the ["features"](./features) subdirectory.
 
+To get a list of the available steps and their documentation, run:
+
+    $ behave --steps-catalog
+
 New step definitions go in the ["features/steps"](./features.steps)
 subdirectory, and use the
 ["hamcrest"](https://pyhamcrest.readthedocs.io/en/latest/tutorial/)
 library to define behavioural expectations.
 
-The available custom steps are not yet documented - look at the sexisting
-feature and step definitions for examples.
+All step definitions receive the current `behave` context as their first
+parameter, and the [environment file](./features/environment.py) adds a few
+useful attributes for use in step implementations:
+
+* `scenario_cleanup`: a `contextlib.ExitStack` instance that can be used to
+  register cleanup operations to run in the `@after_scenario` hook
+
+* `vm_helper`: a custom object for managing local VMs (see
+  `VirtualMachineHelper` in the environment file for details)
+
+* `migration_helper`: a custom object for working with the LeApp tool (see
+  `MigrationHelper` in the environment file for details)
+
+* `http_helper`: a custom object for checking HTTP(S) responses (see
+  `RequestsHelper` in the environment file for details)

--- a/integration-tests/features/environment.py
+++ b/integration-tests/features/environment.py
@@ -1,5 +1,111 @@
 import contextlib
+import pathlib
 import subprocess
+
+##############################
+# General utilities
+##############################
+_TEST_DIR = pathlib.Path(__file__).parent.parent
+_REPO_DIR = _TEST_DIR.parent
+
+# Command execution helper
+def _run_command(cmd, work_dir, ignore_errors):
+    print("  Running {} in {}".format(cmd, work_dir))
+    output = None
+    try:
+        output = subprocess.check_output(
+            cmd, cwd=work_dir, stderr=subprocess.PIPE
+        ).decode()
+    except subprocess.CalledProcessError as exc:
+        output = exc.output.decode()
+        if not ignore_errors:
+            print("=== stdout for failed command ===")
+            print(output)
+            print("=== stderr for failed command ===")
+            print(exc.stderr.decode())
+            raise
+    return output
+
+##############################
+# Test step helpers
+##############################
+_VM_HOSTNAME_PREFIX = "leapp-tests-"
+_VM_DEFS = {
+    _VM_HOSTNAME_PREFIX + path.name: str(path)
+        for path in (_TEST_DIR / "vmdefs").iterdir()
+}
+
+class VirtualMachineHelper(object):
+    """Test step helper to launch and manage VMs
+
+    Currently based specifically on local Vagrant VMs
+    """
+
+    def __init__(self):
+        self._machines = {}
+        self._resource_manager = contextlib.ExitStack()
+
+    def ensure_local_vm(self, name, definition, destroy=False):
+        """Ensure a local VM exists based on the given definition
+
+        *name*: name used to refer to the VM in scenario steps
+        *definition*: directory name in integration-tests/vmdefs
+        *destroy*: whether or not to destroy any existing VM
+        """
+        hostname = _VM_HOSTNAME_PREFIX + definition
+        if hostname not in _VM_DEFS:
+            raise ValueError("Unknown VM image: {}".format(definition))
+        if destroy:
+            # TODO: Look at using "--provision" for fresh VMs
+            #       rather than a full destroy/recreate cycle
+            #       Alternatively: add "reprovision" as a
+            #       separate option for machine creation or
+            #       even make it the default for `destroy=False`
+            self._vm_destroy(hostname)
+        self._vm_up(hostname)
+        if destroy:
+            self._resource_manager.callback(self._vm_destroy, hostname)
+        else:
+            self._resource_manager.callback(self._vm_halt, hostname)
+        self._machines[name] = hostname
+
+    def get_hostname(self, name):
+        """Return the expected hostname for the named machine"""
+        return self._machines[name]
+
+    def close(self):
+        """Halt or destroy all created VMs"""
+        self._resource_manager.close()
+
+    @staticmethod
+    def _run_vagrant(hostname, *args, ignore_errors=False):
+        # TODO: explore https://pypi.python.org/pypi/python-vagrant
+        vm_dir = _VM_DEFS[hostname]
+        cmd = ["vagrant"]
+        cmd.extend(args)
+        return _run_command(cmd, vm_dir, ignore_errors)
+
+    @classmethod
+    def _vm_up(cls, hostname):
+        result = cls._run_vagrant(hostname, "up")
+        print("Started {} VM instance".format(hostname))
+        return result
+
+    @classmethod
+    def _vm_halt(cls, hostname):
+        result = cls._run_vagrant(hostname, "halt", ignore_errors=True)
+        print("Suspended {} VM instance".format(hostname))
+        return result
+
+    @classmethod
+    def _vm_destroy(cls, hostname):
+        result = cls._run_vagrant(hostname, "destroy", ignore_errors=True)
+        print("Destroyed {} VM instance".format(hostname))
+        return result
+
+##############################
+# Test execution hooks
+##############################
 
 def before_all(context):
     # Some steps require sudo, so for convenience in interactive use,
@@ -8,7 +114,9 @@ def before_all(context):
     subprocess.check_output(["sudo", "echo", "Elevated permissions needed"])
 
 def before_scenario(context, scenario):
-    context.resource_manager = contextlib.ExitStack()
+    context.resource_manager = resource_manager = contextlib.ExitStack()
+    context.vm_helper = vm_helper = VirtualMachineHelper()
+    resource_manager.callback(vm_helper.close)
 
 def after_scenario(context, scenario):
     context.resource_manager.close()

--- a/integration-tests/features/steps/common.py
+++ b/integration-tests/features/steps/common.py
@@ -7,6 +7,12 @@ from hamcrest import assert_that, equal_to, not_none, greater_than
 
 @given("the local virtual machines")
 def create_local_machines(context):
+    """Accepts a table of local virtual machine definitions, consisting of:
+
+    * name: the name to be used to refer to the VM in later test steps
+    * definition: the definition directory to use in integration-tests/vmdefs
+    * ensure_fresh: set to 'yes' to destroy an existing VM instead of reusing it
+    """
     vm_helper = context.vm_helper
     for row in context.table:
         ensure_fresh = (row["ensure_fresh"].lower() == "yes")
@@ -23,6 +29,11 @@ def create_local_machines(context):
 
 @when("{source_vm} is redeployed to {target_vm} as a macrocontainer")
 def redeploy_vm_as_macrocontainer(context, source_vm, target_vm):
+    """Uses leapp-tool.py to redeploy the given source VM
+
+    Both *source_vm* and *target_vm* must be named in a previous local
+    virtual machine creation table.
+    """
     context.redeployment_source = source_vm
     context.redeployment_target = target_vm
     migration_helper = context.migration_helper
@@ -38,8 +49,13 @@ def redeploy_vm_as_macrocontainer(context, source_vm, target_vm):
 # Service status checking
 ##############################
 
-@then("the HTTP {status:d} response on port {tcp_port} should match within {wait_duration:g} seconds")
+@then("the HTTP {status:d} response on port {tcp_port:d} should match within {wait_duration:g} seconds")
 def check_http_responses_match(context, tcp_port, status, wait_duration):
+    """Checks a macrocontainer response matches the original VM's response
+
+    The source and target VM are inferred from the most recent preceding
+    redeployment step.
+    """
     original_ip = context.redeployment_source_ip
     redeployed_ip = context.redeployment_target_ip
     assert_that(original_ip, not_none(), "Valid original IP")


### PR DESCRIPTION
This PR migrates the test helpers from functions in the `common` steps file to helper objects passed to step implementations as attributes on the scenario context.

- [x] Migrate local VM management to a `vm_helper` attribute
- [x] Migrate Leapp calls to a `migration_helper` attribute
- [x] Migrate HTTP requests to a `http_helper` attribute
- [x] Document the helper attributes in the integration testing README
