### PR TITLE
Add `target` role responsible for setting up the target env

### DIFF
--- a/ansible_roles/httpd/defaults/main.yml
+++ b/ansible_roles/httpd/defaults/main.yml
@@ -1,0 +1,2 @@
+doc_root: /var/www/html
+hostname: vagrantbox

--- a/ansible_roles/httpd/handlers/main.yml
+++ b/ansible_roles/httpd/handlers/main.yml
@@ -1,0 +1,4 @@
+- name: restart httpd
+  service:
+    name: httpd
+    state: restarted

--- a/ansible_roles/httpd/tasks/main.yml
+++ b/ansible_roles/httpd/tasks/main.yml
@@ -1,0 +1,26 @@
+- name: Install Apache web server
+  yum: 
+    name: '{{ item }}'
+    state: installed
+  with_items:
+    - httpd
+    - libselinux-python
+
+- name: Set SELinux non-eforcing
+  command: setenforce 0
+
+- name: Change default apache vhost
+  template: 
+    src: default.tpl 
+    dest: /etc/httpd/conf.d/000-default.conf
+
+- name: Set global ServerName for apache config
+  lineinfile: 
+    dest: /etc/httpd/conf/httpd.conf 
+    line: "ServerName localhost"
+
+- name: Ensure Apache running
+  service: 
+    name: httpd 
+    state: started 
+    enabled: yes

--- a/ansible_roles/httpd/templates/default.tpl
+++ b/ansible_roles/httpd/templates/default.tpl
@@ -1,0 +1,18 @@
+<VirtualHost *:80>
+  ServerAdmin webmaster@localhost
+  DocumentRoot {{ doc_root }}
+
+  <Directory />
+          Options Indexes FollowSymLinks Includes ExecCGI
+          AllowOverride ALL
+  </Directory>
+
+
+  <Directory {{ doc_root }}>
+    Options Indexes FollowSymLinks Includes ExecCGI
+    AllowOverride All
+  </Directory>
+
+  ErrorLog "/var/log/httpd/html-error_log"
+  CustomLog "/var/log/httpd/html-access_log" common
+</VirtualHost>

--- a/ansible_roles/target/tasks/main.yml
+++ b/ansible_roles/target/tasks/main.yml
@@ -1,0 +1,6 @@
+- name: Ensure target directory is present
+  file:
+    path: /opt/leapp-to
+    state: directory
+    owner: vagrant
+    group: vagrant

--- a/demo/vmdefs/centos7-target/playbook.yml
+++ b/demo/vmdefs/centos7-target/playbook.yml
@@ -2,4 +2,5 @@
   roles:
     - role: init
       key_path: ../../../integration-tests/config/leappto_testing_key.pub
+    - target
     - docker

--- a/integration-tests/vmdefs/centos7-target/ansible/playbook.yml
+++ b/integration-tests/vmdefs/centos7-target/ansible/playbook.yml
@@ -2,4 +2,5 @@
    roles:
     - role: init
       key_path: ../../../config/leappto_testing_key.pub
+    - target
     - docker


### PR DESCRIPTION
Currently we only need to create a `/opt/leapp-to` directory