### PR TITLE
Issue #28: always reprovision test VMs

### DIFF
--- a/integration-tests/features/environment.py
+++ b/integration-tests/features/environment.py
@@ -66,11 +66,6 @@ class VirtualMachineHelper(object):
         if hostname not in _VM_DEFS:
             raise ValueError("Unknown VM image: {}".format(definition))
         if destroy:
-            # TODO: Look at using "--provision" for fresh VMs
-            #       rather than a full destroy/recreate cycle
-            #       Alternatively: add "reprovision" as a
-            #       separate option for machine creation or
-            #       even make it the default for `destroy=False`
             self._vm_destroy(hostname)
         self._vm_up(name, hostname)
         if destroy:
@@ -95,7 +90,7 @@ class VirtualMachineHelper(object):
         return _run_command(cmd, vm_dir, ignore_errors)
 
     def _vm_up(self, name, hostname):
-        result = self._run_vagrant(hostname, "up")
+        result = self._run_vagrant(hostname, "up", "--provision")
         print("Started {} VM instance".format(hostname))
         self.machines[name] = hostname
         return result

--- a/integration-tests/features/steps/common.py
+++ b/integration-tests/features/steps/common.py
@@ -17,6 +17,11 @@ def create_local_machines(context):
     * name: the name to be used to refer to the VM in later test steps
     * definition: the definition directory to use in integration-tests/vmdefs
     * ensure_fresh: set to 'yes' to destroy an existing VM instead of reusing it
+
+    Note: Ansible VM provisioning playbooks are always executed by this step,
+    even when *ensure_fresh* is set to 'no'. For faster test execution, relying
+    on Ansible to restore the VM to a known state is recommended, rather than
+    requiring a full VM create/destroy cycle.
     """
     vm_helper = context.vm_helper
     for row in context.table:


### PR DESCRIPTION
The Ansible playbooks for the test VMs are now always run for each
VM provisioning step, providing the following benefits:

- playbook changes will automatically be picked up on the next test
  run, even when re-using previously created VMs
- playbooks can ensure VMs are reverted to a known state prior to
  use, without having to completely destroy and recreate the VM
- VMs can now readily be reprovisioned within a test scenario