### PR TITLE
Make the IP addresses of the demo VMs configurable

### DIFF
--- a/demo/vmdefs/centos6-guest/Vagrantfile
+++ b/demo/vmdefs/centos6-guest/Vagrantfile
@@ -1,5 +1,7 @@
 VAGRANTFILE_API_VERSION = "2"
 
+ipaddr = ENV.fetch('SRC_IP_ADDR', '10.0.0.10')
+
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     config.vm.box = "centos/6"
     config.vm.hostname = "centos6-app-vm"
@@ -8,7 +10,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     config.vm.network :forwarded_port, guest: 443, host: 443, auto_correct: true # ssl
     config.vm.network :forwarded_port, guest: 3306, host: 3306, auto_correct: true # mysql
     config.vm.network :forwarded_port, guest: 9000, host: 9000, auto_correct: true # phpmyadmin
-    config.vm.network :private_network, ip: "10.0.0.10"
+    config.vm.network :private_network, ip: ipaddr
     config.vm.synced_folder "./", "/var/www/html", type: "rsync", id: "vagrant", :nfs => false,
         :mount_options => ["dmode=777", "fmode=666"]
 
@@ -22,6 +24,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         ansible.sudo = true
     end
 
-    config.vm.provision :shell, inline: "echo Good job, now enjoy your new vbox: http://10.0.0.10"
+    config.vm.provision :shell, inline: "echo Good job, now enjoy your new vbox: http://#{ipaddr}"
 
 end

--- a/demo/vmdefs/centos7-target/Vagrantfile
+++ b/demo/vmdefs/centos7-target/Vagrantfile
@@ -1,12 +1,14 @@
 VAGRANTFILE_API_VERSION = "2"
 
+ipaddr = ENV.fetch('DST_IP_ADDR', '10.0.0.11')
+
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     config.vm.box = "centos/7"
     config.vm.hostname = "centos7-target"
 
     config.vm.network :forwarded_port, guest: 9000, host: 9000, auto_correct: true
     config.vm.network :forwarded_port, guest: 9022, host: 9022, auto_correct: true
-    config.vm.network :private_network, ip: "10.0.0.11"
+    config.vm.network :private_network, ip: ipaddr
 
     config.vm.provider :libvirt do |libvirt|
         libvirt.memory = 1024

--- a/start_vms.sh
+++ b/start_vms.sh
@@ -2,10 +2,10 @@
 
 # Start the source application
 pushd demo/vmdefs/centos6-guest
-sudo vagrant up
+sudo ${SRC_IP_ADDR:+SRC_IP_ADDR=${SRC_IP_ADDR}} vagrant up
 popd
 
 # Start the target container host VM
 pushd demo/vmdefs/centos7-target
-sudo vagrant up
+sudo ${DST_IP_ADDR:+DST_IP_ADDR=${DST_IP_ADDR}} vagrant up
 popd


### PR DESCRIPTION
I have often the problem of being in a 10.0.0.0 network. I then can not run the demo, vagrant complains that: `Error while activating network: Call to virNetworkCreate failed: internal error: Network is already in use by interface enp0s31f6.`

This patch allows one to customize the addresses of the source and target VMs using environment variables SRCIPADDR and DSTIPADDR. Care was taken to keep the defaults in case the variables are unset or null.

Should be probably also done for:
- start_integration_vms.sh and vagrantfiles under integration-tests/vmdefs
- centos7-guest (@shaded-enmity, now it gets 10.0.0.11, isn't it a typo? I would suppose the source VM should get 10.0.0.10.)