### PR TITLE
Add TCP port details to the demo instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ This script iterates over all the subdirectories of `demo/vmdefs` and runs
 ### Running the demonstration via the CLI
 
 First, check that the source VM is showing the
-PHP admin login page, while the target VM isn't
+PHP admin login page at port 9000, while the target VM isn't
 running a HTTP server.
 
 The demo admin login credentials are:
@@ -66,7 +66,7 @@ Then, from the base of the local clone, run:
 
     $ sudo bin/leapp-tool migrate-machine \
            --identity integration-tests/config/leappto_testing_key \
-           -t centos7-target centos6-app-vm
+           --tcp-port 9000:9000 -t centos7-target centos6-app-vm
 
 The target VM should now be showing the PHP admin page,
 with the same information as the source VM.


### PR DESCRIPTION
- without a "--tcp-port 9000:9000" argument to leapp-tool the target VM will not show the PHP admin page
- document that the PHP admin page is on port 9000, this is not obvious.