### PR TITLE
Fix default IP in the drools Vagrant file

### DIFF
--- a/demo/vmdefs/centos6-drools-guest/Vagrantfile
+++ b/demo/vmdefs/centos6-drools-guest/Vagrantfile
@@ -1,6 +1,6 @@
 VAGRANTFILE_API_VERSION = "2"
 
-ipaddr = ENV.fetch('SRC_IP_ADDR', '10.0.0.10')
+ipaddr = ENV.fetch('SRC_IP_ADDR', '10.0.0.20')
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     config.vm.box = "centos/6"


### PR DESCRIPTION
The previous setting of '10.0.0.10' was clashing with the
definition of centos6-guest IP