### PR TITLE
Re-enable the --no-applications usage of virt-inspector

### DIFF
--- a/demo/vmdefs/centos6-drools-guest/Vagrantfile
+++ b/demo/vmdefs/centos6-drools-guest/Vagrantfile
@@ -6,16 +6,16 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     config.vm.box = "centos/6"
     config.vm.hostname = "centos6-drools"
 
-    config.vm.provider :libvirt do |libvirt|
-        libvirt.channel :type => 'unix', :target_name => 'com.redhat.rhevm.vdsm', :target_type => 'virtio'
-    end
     config.vm.network :private_network, ip: ipaddr
     config.vm.synced_folder "./", "/vagrant", type: "rsync", id: "vagrant", :nfs => false,
         :mount_options => ["dmode=777", "fmode=666"]
 
     config.vm.provider :libvirt do |libvirt|
-	libvirt.memory = 2048
-	libvirt.cpus = 2
+        libvirt.memory = 2048
+        libvirt.cpus = 2
+        if libvirt.respond_to? :channel
+            libvirt.channel :type => 'unix', :target_name => 'com.redhat.rhevm.vdsm', :target_type => 'virtio'
+        end
     end
 
     config.vm.provision "ansible" do |ansible|

--- a/demo/vmdefs/centos6-guest/Vagrantfile
+++ b/demo/vmdefs/centos6-guest/Vagrantfile
@@ -6,9 +6,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     config.vm.box = "centos/6"
     config.vm.hostname = "centos6-app-vm"
 
-    config.vm.provider :libvirt do |libvirt|
-        libvirt.channel :type => 'unix', :target_name => 'com.redhat.rhevm.vdsm', :target_type => 'virtio'
-    end
     config.vm.network :forwarded_port, host: 80, guest: 80, auto_correct: true # website
     config.vm.network :forwarded_port, guest: 443, host: 443, auto_correct: true # ssl
     config.vm.network :forwarded_port, guest: 3306, host: 3306, auto_correct: true # mysql
@@ -18,8 +15,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         :mount_options => ["dmode=777", "fmode=666"]
 
     config.vm.provider :libvirt do |libvirt|
-	libvirt.memory = 1024
-	libvirt.cpus = 1
+        libvirt.memory = 1024
+        libvirt.cpus = 1
+        if libvirt.respond_to? :channel
+            libvirt.channel :type => 'unix', :target_name => 'com.redhat.rhevm.vdsm', :target_type => 'virtio'
+        end
     end
 
     config.vm.provision "ansible" do |ansible|

--- a/demo/vmdefs/centos7-target/Vagrantfile
+++ b/demo/vmdefs/centos7-target/Vagrantfile
@@ -6,9 +6,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     config.vm.box = "centos/7"
     config.vm.hostname = "centos7-target"
 
-    config.vm.provider :libvirt do |libvirt|
-        libvirt.channel :type => 'unix', :target_name => 'com.redhat.rhevm.vdsm', :target_type => 'virtio'
-    end
     config.vm.network :forwarded_port, guest: 9000, host: 9000, auto_correct: true
     config.vm.network :forwarded_port, guest: 9022, host: 9022, auto_correct: true
     config.vm.network :private_network, ip: ipaddr
@@ -16,6 +13,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     config.vm.provider :libvirt do |libvirt|
         libvirt.memory = 1024
         libvirt.cpus = 1
+        if libvirt.respond_to? :channel
+            libvirt.channel :type => 'unix', :target_name => 'com.redhat.rhevm.vdsm', :target_type => 'virtio'
+        end
     end
 
     config.vm.provision "ansible" do |ansible|

--- a/integration-tests/vmdefs/centos6-guest-httpd/Vagrantfile
+++ b/integration-tests/vmdefs/centos6-guest-httpd/Vagrantfile
@@ -10,6 +10,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     config.vm.provider :libvirt do |libvirt|
         libvirt.memory = 1024
         libvirt.cpus = 1
+        if libvirt.respond_to? :channel
+            libvirt.channel :type => 'unix', :target_name => 'com.redhat.rhevm.vdsm', :target_type => 'virtio'
+        end
     end
 
     config.vm.provision "ansible" do |ansible|

--- a/integration-tests/vmdefs/centos7-target/Vagrantfile
+++ b/integration-tests/vmdefs/centos7-target/Vagrantfile
@@ -10,6 +10,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     config.vm.provider :libvirt do |libvirt|
         libvirt.memory = 1024
         libvirt.cpus = 1
+        if libvirt.respond_to? :channel
+            libvirt.channel :type => 'unix', :target_name => 'com.redhat.rhevm.vdsm', :target_type => 'virtio'
+        end
     end
 
     config.vm.provision "ansible" do |ansible|

--- a/src/leappto/providers/libvirt_provider.py
+++ b/src/leappto/providers/libvirt_provider.py
@@ -98,9 +98,13 @@ class LibvirtMachineProvider(AbstractMachineProvider):
             :param domain_name: str, which domain to inspect
             :return:
             """
-            cmd = ['virt-inspector', '-d', domain_name, '--no-icon']
-            if self._shallow_scan:
-                cmd.append('--no-applications')
+            inspector_version = check_output(['virt-inspector', '-V'])
+            major, minor, _ = inspector_version.split(' ')[1].split('.', 2)
+            cmd = ['virt-inspector', '-d', domain_name]
+            if int(minor) >= 34 or int(major) > 1:
+                cmd.append('--no-icon')
+                if self._shallow_scan:
+                    cmd.append('--no-applications')
             os_data = check_output(cmd)
             root = ET.fromstring(os_data)
             packages = []

--- a/src/leappto/providers/libvirt_provider.py
+++ b/src/leappto/providers/libvirt_provider.py
@@ -98,7 +98,9 @@ class LibvirtMachineProvider(AbstractMachineProvider):
             :param domain_name: str, which domain to inspect
             :return:
             """
-            cmd = ['virt-inspector', '-d', domain_name]
+            cmd = ['virt-inspector', '-d', domain_name, '--no-icon']
+            if self._shallow_scan:
+                cmd.append('--no-applications')
             os_data = check_output(cmd)
             root = ET.fromstring(os_data)
             packages = []


### PR DESCRIPTION
This PR reenables --no-application and --no-icon usage when available in virt-inspector and adds only channels in vagrant images when they are available.