### PR TITLE
Allow leapp-tool to be run as non-root user

### DIFF
--- a/integration-tests/features/environment.py
+++ b/integration-tests/features/environment.py
@@ -189,7 +189,7 @@ class ClientHelper(object):
 
     @staticmethod
     def _run_leapp(*args):
-        cmd = ["sudo", _LEAPP_TOOL]
+        cmd = [_LEAPP_TOOL]
         cmd.extend(args)
         return _run_command(cmd, work_dir=str(_LEAPP_BIN_DIR), ignore_errors=False)
 

--- a/integration-tests/features/environment.py
+++ b/integration-tests/features/environment.py
@@ -1,5 +1,6 @@
 import contextlib
 import json
+import os
 import pathlib
 import shutil
 import subprocess
@@ -129,6 +130,8 @@ def _install_client():
         _run_command(uninstall, work_dir=str(_REPO_DIR), ignore_errors=False)
     install = base_cmd + ["install", "--python", py27, str(_LEAPP_SRC_DIR)]
     print(_run_command(install, work_dir=str(_REPO_DIR), ignore_errors=False))
+    # Ensure private SSH key is only readable by the current user
+    os.chmod(_SSH_IDENTITY, 0o600)
 
 @attributes
 class MigrationInfo(object):

--- a/src/leappto/cli.py
+++ b/src/leappto/cli.py
@@ -13,9 +13,6 @@ import nmap
 VERSION='leapp-tool {0}'.format(__version__)
 
 def main():
-    if getuid() != 0:
-        print("Please run me as root")
-        exit(-1)
 
     ap = ArgumentParser()
     ap.add_argument('-v', '--version', action='version', version=VERSION, help='display version information')
@@ -102,7 +99,9 @@ def main():
             return self._ssh("sudo bash -c '{}'".format(cmd), **kwargs)
 
         def copy(self):
-            proc = Popen(['virt-tar-out', '-a', self.disk, '/', '-'], stdout=PIPE)
+            # Vagrant always uses qemu:///system, so for now, we always run
+            # virt-tar-out as root, rather than as the current user
+            proc = Popen(['sudo', 'virt-tar-out', '-a', self.disk, '/', '-'], stdout=PIPE)
             return self._ssh('cat > /opt/leapp-to/container.tar.gz', stdin=proc.stdout)
 
         def destroy_containers(self):

--- a/src/leappto/cli.py
+++ b/src/leappto/cli.py
@@ -1,18 +1,41 @@
 """LeApp CLI implementation"""
 
 from argparse import ArgumentParser
-from leappto.providers.libvirt_provider import LibvirtMachineProvider
+from grp import getgrnam, getgrgid
 from json import dumps
 from os import getuid
+from pwd import getpwuid
 from subprocess import Popen, PIPE
 from collections import OrderedDict
+from leappto.providers.libvirt_provider import LibvirtMachineProvider
 from leappto.version import __version__
 import sys
 import nmap
 
 VERSION='leapp-tool {0}'.format(__version__)
 
+_REQUIRED_GROUPS = ["vagrant", "libvirt"]
+def _user_has_required_permissions():
+    """Check user has necessary permissions to reliably run leapp-tool"""
+    uid = getuid()
+    if uid == 0:
+        # root has the necessary access regardless of group membership
+        return True
+    user_info = getpwuid(uid)
+    user_name = user_info.pw_name
+    user_group = getgrgid(user_info.pw_gid).gr_name
+    for group in _REQUIRED_GROUPS:
+        if group != user_group and user_name not in getgrnam(group).gr_mem:
+            return False
+    return True
+
+
 def main():
+
+    if not _user_has_required_permissions():
+        msg = "Run leapp-tool as root, or as a member of all these groups: "
+        print(msg + ",".join(_REQUIRED_GROUPS))
+        exit(-1)
 
     ap = ArgumentParser()
     ap.add_argument('-v', '--version', action='version', version=VERSION, help='display version information')

--- a/src/leappto/providers/libvirt_provider.py
+++ b/src/leappto/providers/libvirt_provider.py
@@ -100,7 +100,9 @@ class LibvirtMachineProvider(AbstractMachineProvider):
             """
             inspector_version = check_output(['virt-inspector', '-V'])
             major, minor, _ = inspector_version.split(' ')[1].split('.', 2)
-            cmd = ['virt-inspector', '-d', domain_name]
+            # Vagrant always uses qemu:///system, so for now, we always run
+            # virt-inspector as root, rather than as the current user
+            cmd = ['sudo', 'virt-inspector', '-d', domain_name]
             if int(minor) >= 34 or int(major) > 1:
                 cmd.append('--no-icon')
                 if self._shallow_scan:

--- a/src/leappto/providers/libvirt_provider.py
+++ b/src/leappto/providers/libvirt_provider.py
@@ -19,10 +19,10 @@ class LibvirtMachine(Machine):
     # virDomainSuspend and virDomainResume so use Virsh
     # for the time being
     def suspend(self):
-        return check_output(['virsh', 'suspend', self.id])
+        return check_output(['sudo', 'virsh', 'suspend', self.id])
 
     def resume(self):
-        return check_output(['virsh', 'resume', self.id])
+        return check_output(['sudo', 'virsh', 'resume', self.id])
 
 
 class LibvirtMachineProvider(AbstractMachineProvider):


### PR DESCRIPTION
Most leapp-tool operations should be executable
without local root privileges, so drop the
requirement to always run it as root.

Instead, "sudo" is used for the commands that
need to be run as root for interoperability
with the Vagrant based tests and demo plugin.