### PR TITLE
#103: Allow use of default SSH credentials in CLI

### DIFF
--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -80,6 +80,8 @@ The following features are currently defined:
   subcommand when migrating stateless applications running under Apache `httpd`
 * `list-machines.feature`: expected behaviour of the `list-machines` subcommand
 * `port-inspect.feature`: expected behaviour of the `port-inspect` subcommand
+* `remote-authentication.feature`: end-to-end testing of available remote
+  authentication options
 
 If a new test scenario doesn't align with any of the existing features, then
 an appropriate new feature should also be defined.
@@ -140,6 +142,8 @@ The following step categories are currently defined:
   subcommand
 * `port_inspect.py`: Steps related specifically to the `port-inspect`
   subcommand
+* `remote_authentication.py`: Steps related specifically to testing the
+  available remote authentication options
 * `common.py`: Steps that are generally useful and don't fit into one of the
   more specific categories. This includes steps relating to the primary
   `migrate-machine` subcommand.

--- a/integration-tests/features/leapp_testing/__init__.py
+++ b/integration-tests/features/leapp_testing/__init__.py
@@ -119,7 +119,8 @@ _LEAPP_TOOL = str(_LEAPP_BIN_DIR / "leapp-tool")
 
 _SSH_USER = "vagrant"
 _SSH_IDENTITY = str(REPO_DIR / "integration-tests/config/leappto_testing_key")
-_DEFAULT_LEAPP_IDENTITY = ['--user', _SSH_USER, '--identity', _SSH_IDENTITY]
+_DEFAULT_LEAPP_USER = ['--user', _SSH_USER]
+_DEFAULT_LEAPP_IDENTITY = ['--identity', _SSH_IDENTITY]
 
 def install_client():
     """Install the CLI and its dependencies into a Python 2.7 environment"""
@@ -179,11 +180,15 @@ class ClientHelper(object):
         self._convert_vm_to_macrocontainer(source_host, target_host)
         return self._get_migration_host_info(source_host, target_host)
 
-    def check_response_time(self, cmd_args, time_limit, complete_identity=False):
+    def check_response_time(self, cmd_args, time_limit, *,
+                            complete_user=False,
+                            complete_identity=False):
         """Check given command completes within the specified time limit
 
         Returns the contents of stdout as a string.
         """
+        if complete_user or complete_identity:
+            cmd_args.extend(_DEFAULT_LEAPP_USER)
         if complete_identity:
             cmd_args.extend(_DEFAULT_LEAPP_IDENTITY)
         start = time.monotonic()

--- a/integration-tests/features/leapp_testing/__init__.py
+++ b/integration-tests/features/leapp_testing/__init__.py
@@ -206,8 +206,8 @@ class ClientHelper(object):
     @staticmethod
     def _start_ssh_agent():
         agent_details = _run_command(["ssh-agent", "-c"]).splitlines()
-        agent_socket = agent_details[0].split()[2]
-        agent_pid = agent_details[1].split()[2]
+        agent_socket = agent_details[0].split()[2].rstrip(";")
+        agent_pid = agent_details[1].split()[2].rstrip(";")
         os.environ["SSH_AUTH_SOCK"] = agent_socket
         os.environ["SSH_AGENT_PID"] = agent_pid
         return agent_socket, agent_pid

--- a/integration-tests/features/leapp_testing/__init__.py
+++ b/integration-tests/features/leapp_testing/__init__.py
@@ -18,8 +18,11 @@ TEST_DIR = pathlib.Path(__file__).parent.parent.parent
 REPO_DIR = TEST_DIR.parent
 
 # Command execution helper
-def _run_command(cmd, work_dir, ignore_errors):
-    print("  Running {} in {}".format(cmd, work_dir))
+def _run_command(cmd, work_dir=None, ignore_errors=False):
+    if work_dir is not None:
+        print("  Running {} in {}".format(cmd, work_dir))
+    else:
+        print("  Running ", cmd)
     output = None
     try:
         output = subprocess.check_output(
@@ -195,6 +198,18 @@ class ClientHelper(object):
         response_time = time.monotonic() - start
         assert_that(response_time, less_than_or_equal_to(time_limit))
         return cmd_output
+
+    @staticmethod
+    def add_default_ssh_key():
+        """Add default testing key to ssh-agent"""
+        cmd = ["ssh-add",  _SSH_IDENTITY]
+        return _run_command(cmd)
+
+    @staticmethod
+    def remove_default_ssh_key():
+        """Remove default testing key from ssh-agent"""
+        cmd = ["ssh-add", "-d", _SSH_IDENTITY + ".pub"]
+        return _run_command(cmd)
 
     @staticmethod
     def _run_leapp(cmd_args, *,

--- a/integration-tests/features/leapp_testing/__init__.py
+++ b/integration-tests/features/leapp_testing/__init__.py
@@ -187,28 +187,34 @@ class ClientHelper(object):
 
         Returns the contents of stdout as a string.
         """
-        if complete_user or complete_identity:
-            cmd_args.extend(_DEFAULT_LEAPP_USER)
-        if complete_identity:
-            cmd_args.extend(_DEFAULT_LEAPP_IDENTITY)
         start = time.monotonic()
-        cmd_output = self._run_leapp(cmd_args)
+        add_default_user = complete_user or complete_identity
+        cmd_output = self._run_leapp(cmd_args,
+                                     add_default_user=add_default_user,
+                                     add_default_identity=complete_identity)
         response_time = time.monotonic() - start
         assert_that(response_time, less_than_or_equal_to(time_limit))
         return cmd_output
 
     @staticmethod
-    def _run_leapp(cmd_args):
+    def _run_leapp(cmd_args, *,
+                   add_default_user=False,
+                   add_default_identity=False):
         cmd = [_LEAPP_TOOL]
         cmd.extend(cmd_args)
+        if add_default_user:
+            cmd.extend(_DEFAULT_LEAPP_USER)
+        if add_default_identity:
+            cmd.extend(_DEFAULT_LEAPP_IDENTITY)
         return _run_command(cmd, work_dir=str(_LEAPP_BIN_DIR), ignore_errors=False)
 
     @classmethod
     def _convert_vm_to_macrocontainer(cls, source_host, target_host):
         cmd_args = ["migrate-machine"]
-        cmd_args.extend(_DEFAULT_LEAPP_IDENTITY)
         cmd_args.extend(["-t", target_host, source_host])
-        result = cls._run_leapp(cmd_args)
+        result = cls._run_leapp(cmd_args,
+                                add_default_user=True,
+                                add_default_identity=True)
         msg = "Redeployed {} as macrocontainer on {}"
         print(msg.format(source_host, target_host))
         return result

--- a/integration-tests/features/remote-authentication.feature
+++ b/integration-tests/features/remote-authentication.feature
@@ -7,7 +7,7 @@ Scenario: Remote access using the --identity option
     Then remote-system should be accessible using the default identity file
 
 Scenario: Remote access using ssh-agent
-   Given ssh-agent is running
+   Given the default identity file is registered with ssh-agent
      And the local virtual machines:
          | name           | definition          | ensure_fresh |
          | remote-system  | centos7-target      | no           |

--- a/integration-tests/features/remote-authentication.feature
+++ b/integration-tests/features/remote-authentication.feature
@@ -1,0 +1,14 @@
+Feature: End-to-end testing of supported remote authentication models
+
+Scenario: Remote access using the --identity option
+   Given the local virtual machines:
+         | name           | definition          | ensure_fresh |
+         | remote-system  | centos7-target      | no           |
+    Then remote-system should be accessible using the default identity file
+
+Scenario: Remote access using ssh-agent
+   Given ssh-agent is running
+     And the local virtual machines:
+         | name           | definition          | ensure_fresh |
+         | remote-system  | centos7-target      | no           |
+    Then remote-system should be accessible using ssh-agent

--- a/integration-tests/features/remote-authentication.feature
+++ b/integration-tests/features/remote-authentication.feature
@@ -7,7 +7,8 @@ Scenario: Remote access using the --identity option
     Then remote-system should be accessible using the default identity file
 
 Scenario: Remote access using ssh-agent
-   Given the default identity file is registered with ssh-agent
+   Given ssh-agent is running
+    And the default identity file is registered with ssh-agent
      And the local virtual machines:
          | name           | definition          | ensure_fresh |
          | remote-system  | centos7-target      | no           |

--- a/integration-tests/features/steps/remote_authentication.py
+++ b/integration-tests/features/steps/remote_authentication.py
@@ -7,10 +7,13 @@ def _make_auth_test_command(context, target):
     # that requires remote access, but also only needs a single target VM
     return ["destroy-containers", context.vm_helper.get_hostname(target)]
 
+@given("ssh-agent is running")
+def ensure_ssh_agent_is_running(context):
+    context.cli_helper.ensure_ssh_agent_is_running(context.scenario_cleanup)
+
 @given("the default identity file is registered with ssh-agent")
 def register_default_identity_with_ssh_agent(context):
-    context.cli_helper.add_default_ssh_key()
-    context.scenario_cleanup.callback(context.cli_helper.remove_default_ssh_key)
+    context.cli_helper.add_default_ssh_key(context.scenario_cleanup)
 
 @then("{target} should be accessible using the default identity file")
 def check_remote_access_with_identity_file(context, target):

--- a/integration-tests/features/steps/remote_authentication.py
+++ b/integration-tests/features/steps/remote_authentication.py
@@ -7,11 +7,10 @@ def _make_auth_test_command(context, target):
     # that requires remote access, but also only needs a single target VM
     return ["destroy-containers", context.vm_helper.get_hostname(target)]
 
-@given("ssh-agent is running")
-def ensure_ssh_agent_is_running(context):
-    # TODO: This is a no-op in a typical user session, but will likely
-    #       need to do something to get this passing in CI
-    pass
+@given("the default identity file is registered with ssh-agent")
+def register_default_identity_with_ssh_agent(context):
+    context.cli_helper.add_default_ssh_key()
+    context.scenario_cleanup.callback(context.cli_helper.remove_default_ssh_key)
 
 @then("{target} should be accessible using the default identity file")
 def check_remote_access_with_identity_file(context, target):

--- a/integration-tests/features/steps/remote_authentication.py
+++ b/integration-tests/features/steps/remote_authentication.py
@@ -1,0 +1,32 @@
+"""Steps for end-to-end testing of remote authentication configuration"""
+from behave import given, then
+
+def _make_auth_test_command(context, target):
+    """Create a leapp-to command to test remote authentication"""
+    # Use destroy-containers, since it's currently the only command
+    # that requires remote access, but also only needs a single target VM
+    return ["destroy-containers", context.vm_helper.get_hostname(target)]
+
+@given("ssh-agent is running")
+def ensure_ssh_agent_is_running(context):
+    # TODO: This is a no-op in a typical user session, but will likely
+    #       need to do something to get this passing in CI
+    pass
+
+@then("{target} should be accessible using the default identity file")
+def check_remote_access_with_identity_file(context, target):
+    """Check remote machine access using the default identity file"""
+    context.cli_helper.check_response_time(
+        _make_auth_test_command(context, target),
+        time_limit=20,
+        complete_identity=True
+    )
+
+@then("{target} should be accessible using ssh-agent")
+def check_remote_access_with_ssh_agent(context, target):
+    """Check remote machine access using ssh-agent (the default)"""
+    context.cli_helper.check_response_time(
+        _make_auth_test_command(context, target),
+        time_limit=20,
+        complete_user=True
+    )

--- a/src/leappto/cli.py
+++ b/src/leappto/cli.py
@@ -97,17 +97,18 @@ def main():
         return None
 
     def _set_ssh_config(username, identity):
-        if not isinstance(identity, str):
-            raise TypeError("identity should be str")
         settings = {
             'StrictHostKeyChecking': 'no',
             'PasswordAuthentication': 'no',
-            'IdentityFile': identity,
         }
         if username is not None:
             if not isinstance(username, str):
                 raise TypeError("username should be str")
             settings['User'] = username
+        if identity is not None:
+            if not isinstance(identity, str):
+                raise TypeError("identity should be str")
+            settings['IdentityFile'] = identity
 
         return ['-o {}={}'.format(k, v) for k, v in settings.items()]
 
@@ -187,9 +188,6 @@ def main():
         print(dumps({'machines': [m._to_dict() for m in lmp.get_machines()]}, indent=3))
 
     elif parsed.action == 'migrate-machine':
-        if not parsed.identity:
-            raise ValueError("Migration requires path to private SSH key to use (--identity)")
-
         if not parsed.target:
             print('! no target specified, creating leappto container package in current directory')
             # TODO: not really for now
@@ -240,8 +238,6 @@ def main():
             sys.exit(result)
 
     elif parsed.action == 'destroy-containers':
-        if not parsed.identity:
-            raise ValueError("Migration requires path to private SSH key to use (--identity)")
         target = parsed.target
 
         lmp = LibvirtMachineProvider()

--- a/src/leappto/cli.py
+++ b/src/leappto/cli.py
@@ -260,8 +260,9 @@ def main():
         )
 
         print('! destroying containers on "{}" VM'.format(target))
-        mc.destroy_containers()
+        result = mc.destroy_containers()
         print('! done')
+        sys.exit(result)
 
     elif parsed.action == 'port-inspect':
         _ERR_STATE = "error"


### PR DESCRIPTION
When no --identity file is specified, the CLI now falls back
on the default SSH credentials (typically provided by ssh-agent)

Closes #103 