### PR TITLE
Leaving the documented tool path in cockpit and fix it during rpm creation for RPM installations

### DIFF
--- a/cockpit/leapp.html
+++ b/cockpit/leapp.html
@@ -153,10 +153,10 @@
         function call_leapp(cmd_args) {
             set_lock_cmd();
             return cockpit.spawn(
-                ["/usr/bin/leapp-tool"].concat(cmd_args),
+                ["/opt/leapp/bin/leapp-tool"].concat(cmd_args),
                 {
                     "superuser": "required",
-                    "directory": "/usr/bin/",
+                    "directory": "/opt/leapp/bin/",
                     "err": "out"
                 }
             );

--- a/leapp.spec
+++ b/leapp.spec
@@ -76,6 +76,7 @@ sed -i "s/install_requires=/install_requires=[],__fake=/g" src/setup.py
 pushd src
 %py2_build_egg
 popd
+sed -i 's/opt\/leapp/usr/g' cockpit/leapp.html
 
 %install
 /bin/mkdir -p %{buildroot}/%{_datadir}/cockpit/leapp


### PR DESCRIPTION
This is a Fix for the problem introduced in #102 