### PR TITLE
Support --ask-pass option in CLI

### DIFF
--- a/ansible_roles/sshd-password-auth/handlers/main.yml
+++ b/ansible_roles/sshd-password-auth/handlers/main.yml
@@ -1,0 +1,2 @@
+- name: Restart sshd
+  service: name=sshd state=restarted

--- a/ansible_roles/sshd-password-auth/tasks/main.yml
+++ b/ansible_roles/sshd-password-auth/tasks/main.yml
@@ -1,0 +1,7 @@
+- name: Allow SSH password authentication
+  # needed for CLI --ask-pass testing
+  lineinfile: dest=/etc/ssh/sshd_config
+              regexp="^PasswordAuthentication"
+              line="PasswordAuthentication yes"
+              state=present
+  notify: Restart sshd

--- a/centos-ci/bootstrap.sh
+++ b/centos-ci/bootstrap.sh
@@ -9,6 +9,9 @@ fi
 yum install -y http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-9.noarch.rpm
 yum install -y python2-pip gcc redhat-rpm-config openssl-devel python-devel
 
+# Interim EPEL-based approach to enable testing of --ask-pass option
+yum install -y sshpass
+
 pip install ansible==2.2.0
 
 cd centos-ci/ansible/

--- a/integration-tests/features/leapp_testing/__init__.py
+++ b/integration-tests/features/leapp_testing/__init__.py
@@ -18,14 +18,10 @@ TEST_DIR = pathlib.Path(__file__).parent.parent.parent
 REPO_DIR = TEST_DIR.parent
 
 # Command execution helper
-<<<<<<< HEAD
-def _run_command(cmd, work_dir=None, ignore_errors=False):
-    """Run non-interactive command and return stdout"""
-=======
 def _run_command(cmd, work_dir=None, ignore_errors=False, as_sudo=False):
-    if as_sudo and isinstance(cmd, list):
+    """Run non-interactive command and return stdout"""
+    if as_sudo:
         cmd.insert(0, 'sudo')
->>>>>>> master
     if work_dir is not None:
         print("  Running {} in {}".format(cmd, work_dir))
     else:
@@ -272,8 +268,7 @@ class ClientHelper(object):
             cmd.extend(_DEFAULT_LEAPP_USER)
         if add_default_identity:
             cmd.extend(_DEFAULT_LEAPP_IDENTITY)
-<<<<<<< HEAD
-        return _run_command(cmd, work_dir=str(_LEAPP_BIN_DIR))
+        return _run_command(cmd, work_dir=str(_LEAPP_BIN_DIR), as_sudo=as_sudo)
 
     @staticmethod
     def _run_leapp_with_askpass(cmd_args):
@@ -285,9 +280,6 @@ class ClientHelper(object):
         cmd.extend(cmd_args)
         cmd.extend(("--user", _SSH_USER, "--ask-pass"))
         return _run_command(cmd, work_dir=str(_LEAPP_BIN_DIR))
-=======
-        return _run_command(cmd, work_dir=str(_LEAPP_BIN_DIR), ignore_errors=False, as_sudo=as_sudo)
->>>>>>> master
 
     @classmethod
     def _convert_vm_to_macrocontainer(cls, source_host, target_host):

--- a/integration-tests/features/leapp_testing/__init__.py
+++ b/integration-tests/features/leapp_testing/__init__.py
@@ -19,10 +19,11 @@ REPO_DIR = TEST_DIR.parent
 
 # Command execution helper
 def _run_command(cmd, work_dir=None, ignore_errors=False):
+    """Run non-interactive command and return stdout"""
     if work_dir is not None:
         print("  Running {} in {}".format(cmd, work_dir))
     else:
-        print("  Running ", cmd)
+        print("  Running {}", cmd)
     output = None
     try:
         output = subprocess.check_output(
@@ -122,6 +123,7 @@ _LEAPP_TOOL = str(_LEAPP_BIN_DIR / "leapp-tool")
 
 _SSH_USER = "vagrant"
 _SSH_IDENTITY = str(REPO_DIR / "integration-tests/config/leappto_testing_key")
+_SSH_PASSWORD = "vagrant"
 _DEFAULT_LEAPP_USER = ['--user', _SSH_USER]
 _DEFAULT_LEAPP_IDENTITY = ['--identity', _SSH_IDENTITY]
 
@@ -184,17 +186,21 @@ class ClientHelper(object):
         return self._get_migration_host_info(source_host, target_host)
 
     def check_response_time(self, cmd_args, time_limit, *,
-                            complete_user=False,
-                            complete_identity=False):
+                            specify_default_user=False,
+                            use_default_identity=False,
+                            use_default_password=False):
         """Check given command completes within the specified time limit
 
         Returns the contents of stdout as a string.
         """
         start = time.monotonic()
-        add_default_user = complete_user or complete_identity
-        cmd_output = self._run_leapp(cmd_args,
-                                     add_default_user=add_default_user,
-                                     add_default_identity=complete_identity)
+        if use_default_password:
+            cmd_output = self._run_leapp_with_askpass(cmd_args)
+        else:
+            add_default_user = specify_default_user or use_default_identity
+            cmd_output = self._run_leapp(cmd_args,
+                                         add_default_user=add_default_user,
+                                         add_default_identity=use_default_identity)
         response_time = time.monotonic() - start
         assert_that(response_time, less_than_or_equal_to(time_limit))
         return cmd_output
@@ -257,7 +263,18 @@ class ClientHelper(object):
             cmd.extend(_DEFAULT_LEAPP_USER)
         if add_default_identity:
             cmd.extend(_DEFAULT_LEAPP_IDENTITY)
-        return _run_command(cmd, work_dir=str(_LEAPP_BIN_DIR), ignore_errors=False)
+        return _run_command(cmd, work_dir=str(_LEAPP_BIN_DIR))
+
+    @staticmethod
+    def _run_leapp_with_askpass(cmd_args):
+        # Helper specifically for --ask-pass testing with default credentials
+        if os.getuid() != 0:
+            err = "sshpass TTY emulation is incompatible with sudo credential caching"
+            raise RuntimeError(err)
+        cmd = ["sshpass", "-p"+_SSH_PASSWORD, _LEAPP_TOOL]
+        cmd.extend(cmd_args)
+        cmd.extend(("--user", _SSH_USER, "--ask-pass"))
+        return _run_command(cmd, work_dir=str(_LEAPP_BIN_DIR))
 
     @classmethod
     def _convert_vm_to_macrocontainer(cls, source_host, target_host):

--- a/integration-tests/features/leapp_testing/__init__.py
+++ b/integration-tests/features/leapp_testing/__init__.py
@@ -23,7 +23,7 @@ def _run_command(cmd, work_dir=None, ignore_errors=False):
     if work_dir is not None:
         print("  Running {} in {}".format(cmd, work_dir))
     else:
-        print("  Running {}", cmd)
+        print("  Running", cmd)
     output = None
     try:
         output = subprocess.check_output(

--- a/integration-tests/features/remote-authentication.feature
+++ b/integration-tests/features/remote-authentication.feature
@@ -6,6 +6,13 @@ Scenario: Remote access using the --identity option
          | remote-system  | centos7-target      | no           |
     Then remote-system should be accessible using the default identity file
 
+Scenario: Remote access using the --ask-pass option
+   Given the tests are being run as root
+     And the local virtual machines:
+         | name           | definition          | ensure_fresh |
+         | remote-system  | centos7-target      | no           |
+    Then remote-system should be accessible using the default password
+
 Scenario: Remote access using ssh-agent
    Given ssh-agent is running
     And the default identity file is registered with ssh-agent

--- a/integration-tests/features/steps/destroy_containers.py
+++ b/integration-tests/features/steps/destroy_containers.py
@@ -8,5 +8,5 @@ def check_destroy_containers(context, target, time_limit):
     context.cli_helper.check_response_time(
         ["destroy-containers", context.vm_helper.get_hostname(target)],
         time_limit,
-        complete_identity=True
+        use_default_identity=True
     )

--- a/integration-tests/features/steps/remote_authentication.py
+++ b/integration-tests/features/steps/remote_authentication.py
@@ -1,6 +1,14 @@
 """Steps for end-to-end testing of remote authentication configuration"""
 from behave import given, then
 
+import os
+
+@given("the tests are being run as root")
+def skip_unless_running_as_root(context):
+    """Skips the scenario if the tests are run as a non-root user"""
+    if os.getuid() != 0:
+        context.scenario.skip("This scenario can only be run as root")
+
 def _make_auth_test_command(context, target):
     """Create a leapp-to command to test remote authentication"""
     # Use destroy-containers, since it's currently the only command
@@ -21,8 +29,18 @@ def check_remote_access_with_identity_file(context, target):
     context.cli_helper.check_response_time(
         _make_auth_test_command(context, target),
         time_limit=20,
-        complete_identity=True
+        use_default_identity=True
     )
+
+@then("{target} should be accessible using the default password")
+def check_remote_access_with_interactive_password_entry(context, target):
+    """Check remote machine access using the default user & password"""
+    context.cli_helper.check_response_time(
+        _make_auth_test_command(context, target),
+        time_limit=20,
+        use_default_password=True
+    )
+
 
 @then("{target} should be accessible using ssh-agent")
 def check_remote_access_with_ssh_agent(context, target):
@@ -30,5 +48,5 @@ def check_remote_access_with_ssh_agent(context, target):
     context.cli_helper.check_response_time(
         _make_auth_test_command(context, target),
         time_limit=20,
-        complete_user=True
+        specify_default_user=True
     )

--- a/integration-tests/vmdefs/centos7-target/ansible/playbook.yml
+++ b/integration-tests/vmdefs/centos7-target/ansible/playbook.yml
@@ -4,3 +4,5 @@
       key_path: ../../../config/leappto_testing_key.pub
     - target
     - docker
+    # Needed for CLI --ask-pass testing
+    - sshd-password-auth

--- a/leapp.spec
+++ b/leapp.spec
@@ -1,6 +1,6 @@
 Name:       leapp
 Version:    0.0.1
-Release:    5
+Release:    6
 Summary:    leapp tool rpm
 
 Group:      Unspecified
@@ -43,6 +43,7 @@ Requires:   libguestfs-tools-c
 Requires:   libvirt-client
 Requires:   libvirt-python
 Requires:   nmap
+Requires:   sshpass
 Requires:   python-enum34
 Requires:   python2
 Requires:   python2-nmap
@@ -103,6 +104,10 @@ popd
 
 
 %changelog
+
+* Mon May 17 2017 Nick Coghlan <ncoghlan@redhat.com> 0.0.1-6
+- Add sshpass dependency for --ask-pass support in CLI (ncoghlan@redhat.com)
+
 * Mon May 08 2017 Vinzenz Feenstra <vfeenstr@redhat.com> 0.0.1-5
 - Touch non existing file workaround not necessary anymore files have been
   already added (vfeenstr@redhat.com)


### PR DESCRIPTION
This uses getpass.getpass() to interactively retrieve a password
from an interactive prompt, and then sshpass to pass it along
to ssh via a custom file descriptor.

The associated test case similarly uses sshpass to supply the
test password to the LeApp CLI.

To avoid problems with the default per-tty credential caching
in sudo, the test case only runs when the tests are being
run as root (as is the case in CI).