### PR TITLE
Enable Cockpit plugin integration testing

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -14,4 +14,17 @@ ansible = ">= 2.0"
 pipsi = "*"
 pipenv = ">= 3.6.0"
 splinter = "*"
+
+# We restrict ourselves to older versions of Selenium for the Cockpit plugin
+# testing as:
+#
+#  - Selenium 3.0+ requires geckodriver, the WebDriver interface to Firefox
+#  - geckodriver needs a newer version of Firefox than CentOS 7 provides
+#  - even without that, the tests currently fail when run through geckodriver
+#  - Mozilla themselves say "Marionette and geckodriver are not yet feature
+#    complete. This means that they do not yet offer full conformance with the
+#    WebDriver standard or complete compatibility with Selenium."
+#
+# See https://developer.mozilla.org/en-US/docs/Mozilla/QA/Marionette/WebDriver
+# for more details on the development status of Marionette & geckodriver
 selenium = "< 3.0"

--- a/Pipfile
+++ b/Pipfile
@@ -18,12 +18,15 @@ splinter = "*"
 # We restrict ourselves to older versions of Selenium for the Cockpit plugin
 # testing as:
 #
+#  - CentOS 7 offers a relatively old version of Firefox by default
 #  - Selenium 3.0+ requires geckodriver, the WebDriver interface to Firefox
-#  - geckodriver needs a newer version of Firefox than CentOS 7 provides
-#  - even without that, the tests currently fail when run through geckodriver
-#  - Mozilla themselves say "Marionette and geckodriver are not yet feature
-#    complete. This means that they do not yet offer full conformance with the
-#    WebDriver standard or complete compatibility with Selenium."
+#  - Mozilla themselves say:
+#    - "Marionette and geckodriver are not yet feature complete. This means
+#      that they do not yet offer full conformance with the WebDriver standard
+#      or complete compatibility with Selenium."
+#    - "It is recommended to use the latest releases of geckodriver, Firefox,
+#      and Selenium. Generally speaking, the more recent the Firefox release,
+#      the more compatibility and conformance fixes you will get."
 #
 # See https://developer.mozilla.org/en-US/docs/Mozilla/QA/Marionette/WebDriver
 # for more details on the development status of Marionette & geckodriver

--- a/centos-ci/ansible/playbook.yml
+++ b/centos-ci/ansible/playbook.yml
@@ -2,3 +2,4 @@
   roles:
     - scl
     - vagrant
+    - cockpit-integration

--- a/centos-ci/ansible/roles/cockpit-integration/tasks/main.yml
+++ b/centos-ci/ansible/roles/cockpit-integration/tasks/main.yml
@@ -9,7 +9,7 @@
 
 # Temporary symlink until we actually build and install the LeApp RPMs in CI
 - name: Symlink LeApp development CLI
-- file:
+  file:
     src: "{{ playbook_dir | dirname | dirname }}"
     dest: /opt/leapp/
     owner: root

--- a/centos-ci/ansible/roles/cockpit-integration/tasks/main.yml
+++ b/centos-ci/ansible/roles/cockpit-integration/tasks/main.yml
@@ -6,3 +6,13 @@
     - cockpit
     - xorg-x11-server-Xvfb
     - firefox
+
+# Temporary symlink until we actually build and install the LeApp RPMs in CI
+- name: Symlink LeApp development CLI
+- file:
+    src: {{ playbook_dir | dirname | dirname }}
+    dest: /opt/leapp/
+    owner: root
+    group: root
+    state: link
+    mode: 0755

--- a/centos-ci/ansible/roles/cockpit-integration/tasks/main.yml
+++ b/centos-ci/ansible/roles/cockpit-integration/tasks/main.yml
@@ -10,7 +10,7 @@
 # Temporary symlink until we actually build and install the LeApp RPMs in CI
 - name: Symlink LeApp development CLI
 - file:
-    src: {{ playbook_dir | dirname | dirname }}
+    src: "{{ playbook_dir | dirname | dirname }}"
     dest: /opt/leapp/
     owner: root
     group: root

--- a/centos-ci/ansible/roles/cockpit-integration/tasks/main.yml
+++ b/centos-ci/ansible/roles/cockpit-integration/tasks/main.yml
@@ -11,7 +11,7 @@
 - name: Symlink LeApp development CLI
   file:
     src: "{{ playbook_dir | dirname | dirname }}"
-    dest: /opt/leapp/
+    dest: /opt/leapp
     owner: root
     group: root
     state: link

--- a/centos-ci/ansible/roles/cockpit-integration/tasks/main.yml
+++ b/centos-ci/ansible/roles/cockpit-integration/tasks/main.yml
@@ -7,6 +7,12 @@
     - xorg-x11-server-Xvfb
     - firefox
 
+- name: Enable Cockpit
+  systemd:
+    name: cockpit.socket
+    enabled: true
+    state: started
+
 # Temporary symlink until we actually build and install the LeApp RPMs in CI
 - name: Symlink LeApp development CLI
   file:

--- a/centos-ci/ansible/roles/cockpit-integration/tasks/main.yml
+++ b/centos-ci/ansible/roles/cockpit-integration/tasks/main.yml
@@ -1,0 +1,12 @@
+- name: Install Required System Packages
+  yum:
+    name: '{{ item }}'
+    state: present
+  with_items:
+    - cockpit
+    - xorg-X11-server-Xvfb
+    - firefox
+
+- name: Check geckodriver
+  shell: geckodriver --version
+

--- a/centos-ci/ansible/roles/cockpit-integration/tasks/main.yml
+++ b/centos-ci/ansible/roles/cockpit-integration/tasks/main.yml
@@ -6,7 +6,3 @@
     - cockpit
     - xorg-x11-server-Xvfb
     - firefox
-
-- name: Check geckodriver
-  shell: geckodriver --version
-

--- a/centos-ci/ansible/roles/cockpit-integration/tasks/main.yml
+++ b/centos-ci/ansible/roles/cockpit-integration/tasks/main.yml
@@ -4,7 +4,7 @@
     state: present
   with_items:
     - cockpit
-    - xorg-X11-server-Xvfb
+    - xorg-x11-server-Xvfb
     - firefox
 
 - name: Check geckodriver

--- a/centos-ci/bootstrap.sh
+++ b/centos-ci/bootstrap.sh
@@ -15,4 +15,7 @@ cd centos-ci/ansible/
 
 ansible-playbook -i 'localhost,' -c local playbook.yml
 
+Xvfb :19 -screen 0 1024x768x16 &
+export DISPLAY=:19
+
 scl enable rh-python35 sclo-vagrant1 -- sh -xc "cd ../.. && pipenv shell 'cd integration-tests && behave --no-color --junit; exit \\\$?'"

--- a/integration-tests/features/cockpit-demo.feature
+++ b/integration-tests/features/cockpit-demo.feature
@@ -1,7 +1,5 @@
 Feature: Demonstration Cockpit plugin
 
-# Currently still WIP due to dependency on Firefox for scenario execution
-@wip
 Scenario: Initial page visit
   Given Cockpit is installed on the testing host
     And the demonstration user exists

--- a/integration-tests/features/cockpit-demo.feature
+++ b/integration-tests/features/cockpit-demo.feature
@@ -2,7 +2,6 @@ Feature: Demonstration Cockpit plugin
 
 # Currently still WIP due to dependency on Firefox for scenario execution
 @wip
-@skip
 Scenario: Initial page visit
   Given Cockpit is installed on the testing host
     And the demonstration user exists

--- a/integration-tests/features/steps/cockpit_demo.py
+++ b/integration-tests/features/steps/cockpit_demo.py
@@ -43,7 +43,7 @@ def check_demo_machine_listing(context, time_limit):
     expected_machines = context.vm_helper.machines
     expected_hosts = sorted(host for name, host in expected_machines.items())
     missing = session.list_missing_machines(expected_hosts, time_limit)
-    assert_that(missing, equal_to([]))
+    assert_that(missing, equal_to([]), "Machines missing from listing")
 
 # Helper functions and classes
 # Note: these are all candidates for moving to the `behave` context

--- a/integration-tests/features/steps/cockpit_demo.py
+++ b/integration-tests/features/steps/cockpit_demo.py
@@ -168,6 +168,7 @@ class DemoCockpitSession(object):
         browser = self._browser
         user = self._user
         browser.visit(self._cockpit_url)
+        assert_that(browser.status_code.is_success(), "Failed to load login page")
         # browser.fill_form looks form elements up by name rather than id, so we
         # find and populate the form elements individually
         browser.find_by_id("login-user-input").fill(user.username)


### PR DESCRIPTION
To help avoid further regressions along the lines of #122, this enables
execution of the Cockpit plugin integration tests during CI