### PR TITLE
Restore ability to run tests as non-root user

### DIFF
--- a/docs/source/integration-tests.rst
+++ b/docs/source/integration-tests.rst
@@ -127,6 +127,17 @@ This allows an initial draft of the desired behaviour to be specified and
 merged prior to starting work on the implementation of the new behaviour and
 any new test steps required.
 
+Some scenarios may be slow or encounter other problems when run as a non-root
+user. These can be marked with ``@root_recommended`` and will then only be
+executed when either that tag is specified, or else the test suite is running as
+the root user (as it does in pre-merge CI).
+
+To run these tests as a regular user for local testing of a particular feature
+without running the whole test suite as root, specify::
+
+    behave -i <feature-of-interest> --tags root_recommended
+
+
 Adding new steps to the steps catalog
 -------------------------------------
 

--- a/integration-tests/features/cockpit-demo.feature
+++ b/integration-tests/features/cockpit-demo.feature
@@ -1,10 +1,11 @@
 Feature: Demonstration Cockpit plugin
 
+@root_recommended
 Scenario: Initial page visit
   Given Cockpit is installed on the testing host
     And the demonstration user exists
     And the demonstration plugin is installed
-    And the local virtual machines:
+    And the local virtual machines as root:
          | name       | definition          | ensure_fresh |
          | vm1        | centos6-guest-httpd | no           |
          | vm2        | centos7-target      | no           |

--- a/integration-tests/features/leapp_testing/__init__.py
+++ b/integration-tests/features/leapp_testing/__init__.py
@@ -92,7 +92,7 @@ class VirtualMachineHelper(object):
     def _run_vagrant(hostname, *args, as_root=False, ignore_errors=False):
         # TODO: explore https://pypi.python.org/pypi/python-vagrant
         vm_dir = _VM_DEFS[hostname]
-        if as_root:
+        if as_root and os.getuid() != 0:
             cmd = ["sudo", "vagrant"]
         else:
             cmd = ["vagrant"]

--- a/integration-tests/features/leapp_testing/__init__.py
+++ b/integration-tests/features/leapp_testing/__init__.py
@@ -62,7 +62,7 @@ class VirtualMachineHelper(object):
         self.machines = {}
         self._resource_manager = contextlib.ExitStack()
 
-    def ensure_local_vm(self, name, definition, destroy=False):
+    def ensure_local_vm(self, name, definition, destroy=False, *, as_root=False):
         """Ensure a local VM exists based on the given definition
 
         *name*: name used to refer to the VM in scenario steps
@@ -73,12 +73,12 @@ class VirtualMachineHelper(object):
         if hostname not in _VM_DEFS:
             raise ValueError("Unknown VM image: {}".format(definition))
         if destroy:
-            self._vm_destroy(hostname)
-        self._vm_up(name, hostname)
+            self._vm_destroy(name, hostname, as_root=as_root)
+        self._vm_up(name, hostname, as_root=as_root)
         if destroy:
-            self._resource_manager.callback(self._vm_destroy, name)
+            self._resource_manager.callback(self._vm_destroy, name, hostname, as_root=as_root)
         else:
-            self._resource_manager.callback(self._vm_halt, name)
+            self._resource_manager.callback(self._vm_halt, name, hostname, as_root=as_root)
 
     def get_hostname(self, name):
         """Return the expected hostname for the named machine"""
@@ -89,28 +89,37 @@ class VirtualMachineHelper(object):
         self._resource_manager.close()
 
     @staticmethod
-    def _run_vagrant(hostname, *args, ignore_errors=False):
+    def _run_vagrant(hostname, *args, as_root=False, ignore_errors=False):
         # TODO: explore https://pypi.python.org/pypi/python-vagrant
         vm_dir = _VM_DEFS[hostname]
-        cmd = ["vagrant"]
+        if as_root:
+            cmd = ["sudo", "vagrant"]
+        else:
+            cmd = ["vagrant"]
         cmd.extend(args)
         return _run_command(cmd, vm_dir, ignore_errors)
 
-    def _vm_up(self, name, hostname):
-        result = self._run_vagrant(hostname, "up", "--provision")
+    def _vm_up(self, name, hostname, *, as_root=False):
+        result = self._run_vagrant(hostname, "up", "--provision", as_root=as_root)
         print("Started {} VM instance".format(hostname))
         self.machines[name] = hostname
         return result
 
-    def _vm_halt(self, name):
-        hostname = self.machines.pop(name)
-        result = self._run_vagrant(hostname, "halt", ignore_errors=True)
+    def _vm_halt(self, name, hostname, *, as_root=False):
+        try:
+            hostname = self.machines.pop(name)
+        except KeyError:
+            pass
+        result = self._run_vagrant(hostname, "halt", as_root=as_root, ignore_errors=True)
         print("Suspended {} VM instance".format(hostname))
         return result
 
-    def _vm_destroy(self, name):
-        hostname = self.machines.pop(name)
-        result = self._run_vagrant(hostname, "destroy", ignore_errors=True)
+    def _vm_destroy(self, name, hostname, *, as_root=False):
+        try:
+            hostname = self.machines.pop(name)
+        except KeyError:
+            pass
+        result = self._run_vagrant(hostname, "destroy", as_root=as_root, ignore_errors=True)
         print("Destroyed {} VM instance".format(hostname))
         return result
 

--- a/integration-tests/features/steps/common.py
+++ b/integration-tests/features/steps/common.py
@@ -27,10 +27,10 @@ def create_local_machines(context, user=None):
     When the tests are run as a non-root user, specifying 'as root' implies
     'ensure_fresh=yes', even if it is otherwise set to 'no'
     """
-    as_root = (user == "root")
-    if user is not None and not as_root:
+    if user not in (None, "root"):
         msg = "VMs must be started as either root or the current user"
         raise RuntimeError(msg)
+    as_root = (user == "root")
     vm_helper = context.vm_helper
     for row in context.table:
         ensure_fresh = (row["ensure_fresh"].lower() == "yes")


### PR DESCRIPTION
Due to recent changes in the way source & target VM lookup
is handled, the Cockpit plugin integration test now requires
that the VMs it uses be started by the root user (otherwise
it fails to find them).

While this isn't a problem for CI (where the tests run as
root), it causes problems when running the tests as a
normal user in a local `pipenv shell` session.

To fix that, the follow changes have been made:

- test scenarios can now indicate they need their VMs
  started as root, and if the tests are running as a
  normal user, the VMs will be destroyed and recreated
  by root
- test scenarios can now be marked with `@root_recommended`
  to indicate that they're really slow or otherwise
  problematic when run as a non-root user
- the Cockpit plugin integration test has been updated to
  use both of these features