### PR TITLE
check-target subcommand

### DIFF
--- a/integration-tests/features/check-target.feature
+++ b/integration-tests/features/check-target.feature
@@ -1,0 +1,16 @@
+Feature: Checking usability of target virtual machine 
+
+Scenario: Checking for already used names on target VM
+   Given the local virtual machines:
+         | name       | definition          | ensure_fresh |
+         | target     | centos7-target      | no           |
+     And the following names claimed on target:
+         | name       | kind                |
+         | app1       | idle macrocontainer |
+         | app2       | idle macrocontainer |
+         | container1 | idle container      |
+         | container2 | idle container      |
+         | storage1   | macrocontainer dir  |
+         | storage2   | macrocontainer dir  |
+    Then checking target usability should take less than 10 seconds
+     And all claimed names should be reported exactly once

--- a/integration-tests/features/check-target.feature
+++ b/integration-tests/features/check-target.feature
@@ -1,4 +1,4 @@
-Feature: Checking usability of target virtual machine 
+Feature: Checking usability of target virtual machine
 
 Scenario: Checking for already used names on target VM
    Given the local virtual machines:

--- a/integration-tests/features/httpd-stateless.feature
+++ b/integration-tests/features/httpd-stateless.feature
@@ -7,9 +7,7 @@ Scenario: HTTP default server page
          | target     | centos7-target      | no           |
     When app-source is redeployed to target as a macrocontainer
     Then the HTTP 403 response on port 80 should match within 120 seconds
-     # TODO: Add a clause that ensures we check target viability *early*,
-     #       rather than leaving it until after exporting the source app
-     # And attempting a second redeployment should fail within 10 seconds
+     And attempting another redeployment should fail within 10 seconds
 
 Scenario: HTTP default server page - migrated by using rsync
    Given the local virtual machines:
@@ -18,6 +16,4 @@ Scenario: HTTP default server page - migrated by using rsync
          | target     | centos7-target      | no           |
     When app-source is redeployed to target as a macrocontainer and rsync is used for fs migration
     Then the HTTP 403 response on port 80 should match within 120 seconds
-     # TODO: Add a clause that ensures we check target viability *early*,
-     #       rather than leaving it until after exporting the source app
-     # And attempting a second redeployment should fail within 10 seconds
+     And attempting another redeployment should fail within 10 seconds

--- a/integration-tests/features/httpd-stateless.feature
+++ b/integration-tests/features/httpd-stateless.feature
@@ -7,7 +7,9 @@ Scenario: HTTP default server page
          | target     | centos7-target      | no           |
     When app-source is redeployed to target as a macrocontainer
     Then the HTTP 403 response on port 80 should match within 120 seconds
-     And attempting another redeployment should fail within 10 seconds
+     # TODO: Add a clause that ensures we check target viability *early*,
+     #       rather than leaving it until after exporting the source app
+     # And attempting a second redeployment should fail within 10 seconds
 
 Scenario: HTTP default server page - migrated by using rsync
    Given the local virtual machines:
@@ -16,4 +18,6 @@ Scenario: HTTP default server page - migrated by using rsync
          | target     | centos7-target      | no           |
     When app-source is redeployed to target as a macrocontainer and rsync is used for fs migration
     Then the HTTP 403 response on port 80 should match within 120 seconds
-     And attempting another redeployment should fail within 10 seconds
+     # TODO: Add a clause that ensures we check target viability *early*,
+     #       rather than leaving it until after exporting the source app
+     # And attempting a second redeployment should fail within 10 seconds

--- a/integration-tests/features/leapp_testing/__init__.py
+++ b/integration-tests/features/leapp_testing/__init__.py
@@ -199,7 +199,7 @@ class MigrationInfo(object):
     target_ip = attrib()
 
     @classmethod
-    def from_vm_list(cls, machines, source_host, target_host, return_code):
+    def from_vm_list(cls, machines, source_host, target_host):
         """Build a result given a local VM listing and migration hostnames"""
         vm_count = len(machines)
         source_ip = target_ip = None

--- a/integration-tests/features/leapp_testing/__init__.py
+++ b/integration-tests/features/leapp_testing/__init__.py
@@ -93,6 +93,12 @@ class VirtualMachineHelper(object):
         """Halt or destroy all created VMs"""
         self._resource_manager.close()
 
+    def run_remote_command(self, name, *cmd, ignore_errors=False):
+        """Run the given command on the named machine"""
+        hostname = self.machines[name]
+        return self._run_vagrant(hostname, "ssh", "--", *cmd,
+                                 ignore_errors=ignore_errors)
+
     @staticmethod
     def _run_vagrant(hostname, *args, as_root=False, ignore_errors=False):
         # TODO: explore https://pypi.python.org/pypi/python-vagrant
@@ -185,13 +191,15 @@ class MigrationInfo(object):
     *local_vm_count*: Total number of local VMs found during migration
     *source_ip*: host accessible IP address found for source VM
     *target_ip*: host accessible IP address found for target VM
+    *command_succeeded*: True if the command return code was 0
+    *command_failed*: logical inverse of command_succeeded
     """
     local_vm_count = attrib()
     source_ip = attrib()
     target_ip = attrib()
 
     @classmethod
-    def from_vm_list(cls, machines, source_host, target_host):
+    def from_vm_list(cls, machines, source_host, target_host, return_code):
         """Build a result given a local VM listing and migration hostnames"""
         vm_count = len(machines)
         source_ip = target_ip = None
@@ -215,6 +223,13 @@ class ClientHelper(object):
     def __init__(self, vm_helper):
         self._vm_helper = vm_helper
 
+    def make_migration_command(self, source_vm, target_vm, migration_opt=None):
+        """Get command to recreate source VM as a macrocontainer on given target VM"""
+        vm_helper = self._vm_helper
+        source_host = vm_helper.get_hostname(source_vm)
+        target_host = vm_helper.get_hostname(target_vm)
+        return self._make_redeployment_command(source_host, target_host, migration_opt)
+
     def redeploy_as_macrocontainer(self, source_vm, target_vm, migration_opt=None):
         """Recreate source VM as a macrocontainer on given target VM"""
         vm_helper = self._vm_helper
@@ -227,7 +242,8 @@ class ClientHelper(object):
                             specify_default_user=False,
                             use_default_identity=False,
                             use_default_password=False,
-                            as_sudo=False):
+                            as_sudo=False,
+                            expect_failure=False):
         """Check given command completes within the specified time limit
 
         Returns the contents of stdout as a string.
@@ -238,11 +254,18 @@ class ClientHelper(object):
             cmd_output = self._run_leapp_with_askpass(cmd_args, is_migrate=is_migrate)
         else:
             add_default_user = specify_default_user or use_default_identity
-            cmd_output = self._run_leapp(cmd_args,
-                                         add_default_user=add_default_user,
-                                         add_default_identity=use_default_identity,
-                                         is_migrate=is_migrate,
-                                         as_sudo=as_sudo)
+            try:
+                cmd_output = self._run_leapp(cmd_args,
+                                            add_default_user=add_default_user,
+                                            add_default_identity=use_default_identity,
+                                            is_migrate=is_migrate,
+                                            as_sudo=as_sudo)
+            except subprocess.CalledProcessError:
+                if not expect_failure:
+                    raise
+            else:
+                if expect_failure:
+                    raise AssertionError("Command succeeded unexpectedly")
         response_time = time.monotonic() - start
         assert_that(response_time, less_than_or_equal_to(time_limit))
         return cmd_output
@@ -329,11 +352,19 @@ class ClientHelper(object):
         return _run_command(cmd, work_dir=str(_LEAPP_BIN_DIR))
 
     @classmethod
-    def _convert_vm_to_macrocontainer(cls, source_host, target_host, migration_opt):
+    def _make_redeployment_command(cls, source_host, target_host, migration_opt):
         cmd_args = ["migrate-machine", "--tcp-port", "80:80"]
         if migration_opt == 'rsync':
             cmd_args.append('--use-rsync')
         cmd_args.extend(["-t", target_host, source_host])
+        return cmd_args
+
+    @classmethod
+    def _convert_vm_to_macrocontainer(cls, source_host, target_host, migration_opt):
+        as_sudo = False
+        cmd_args = cls._make_redeployment_command(source_host, target_host, migration_opt)
+        if '--use-rsync' in cmd_args:
+            as_sudo = True
         result = cls._run_leapp(cmd_args,
                                 add_default_user=True,
                                 add_default_identity=True,

--- a/integration-tests/features/steps/check_target.py
+++ b/integration-tests/features/steps/check_target.py
@@ -1,0 +1,75 @@
+"""Steps to test the "destroy-containers" subcommand"""
+from behave import given, then
+from hamcrest import assert_that, equal_to
+from functools import partial
+
+class ClaimHelper(object):
+    """Helper to claim names on a target VM in ways check-target will detect"""
+    def __init__(self, run_remote):
+        self._run_remote = run_remote
+
+    def make_macrocontainer_dir(self, claimed_name):
+        """Create a macrocontainer storage directory with the given name"""
+        storage_dir = "/var/lib/leapp/macrocontainers/"
+        cmd = ["mkdir", "-p", storage_dir + claimed_name]
+        return self._run_remote(*cmd)
+
+    def make_idle_container(self, claimed_name):
+        """Create an idle container with the given name"""
+        cmd = ["sudo", "docker", "run", "--name", claimed_name, "centos:7"]
+        # The tests don't currently clean up arbitrary containers when
+        # reprovisioning the target (to allow for containerised system
+        # services), so this ignores errors on the assumption they're just
+        # "this container already exists"
+        return self._run_remote(*cmd, ignore_errors=True)
+
+    def make_idle_macrocontainer(self, claimed_name):
+        """Create an idle container with the given name"""
+        self.make_macrocontainer_dir(claimed_name)
+        return self.make_idle_container(claimed_name)
+
+    def claim_name(self, claimed_name, kind):
+        """Claim a name on the target using the nominated kind"""
+        claim_method = getattr(self, "make_" + "_".join(kind.split()))
+        return claim_method(claimed_name)
+
+
+@given("the following names claimed on {target}")
+def claim_names_on_target_vm(context, target):
+    """Accepts a table of claimed names on the target VM, consisting of:
+
+    * name: the name expected to be reported for the claim by check-target
+    * kind: the kind of "claim" to create on the target VM
+
+    The following kinds of claims can be specified:
+
+    * "macrocontainer dir": creates an empty macrocontainer storage directory
+    * "idle container": creates an idle CentOS 7 container
+    * "idle macrocontainer": creates both a container and a storage directory
+    """
+    run_remote = partial(context.vm_helper.run_remote_command, target)
+    helper = ClaimHelper(run_remote)
+    claimed_names = set()
+    for row in context.table:
+        claimed_name = row["name"]
+        if claimed_name in claimed_names:
+            msg = "Attempted to claim the same name twice: " + claimed_name
+            raise RuntimeError(msg)
+        helper.claim_name(claimed_name, row["kind"])
+        claimed_names.add(claimed_name)
+    context._claimed_names = sorted(claimed_names)
+
+@then("checking {target} usability should take less than {time_limit:g} seconds")
+def run_check_target(context, target, time_limit):
+    """Retrieve claimed names from designated target"""
+    command_output = context.cli_helper.check_response_time(
+        ["check-target", context.vm_helper.get_hostname(target)],
+        time_limit,
+        use_default_identity=True
+    )
+    context._reported_names = command_output.splitlines()
+
+@then("all claimed names should be reported exactly once")
+def check_claimed_names(context):
+    """Check claimed names match those in the expected list"""
+    assert_that(context._reported_names, equal_to(context._claimed_names))

--- a/integration-tests/features/steps/remote_authentication.py
+++ b/integration-tests/features/steps/remote_authentication.py
@@ -11,9 +11,7 @@ def skip_unless_running_as_root(context):
 
 def _make_auth_test_command(context, target):
     """Create a leapp-to command to test remote authentication"""
-    # Use destroy-containers, since it's currently the only command
-    # that requires remote access, but also only needs a single target VM
-    return ["destroy-containers", context.vm_helper.get_hostname(target)]
+    return ["check-target", context.vm_helper.get_hostname(target)]
 
 @given("ssh-agent is running")
 def ensure_ssh_agent_is_running(context):


### PR DESCRIPTION
- reports names already claimed on target system
- implicitly checks for privileged access to target

Additional changes:

- auth integration tests now use check-target
- new test setup step to claim names on target systems
- new test step to rerun the previous migration command