### PR TITLE
Use EPEL Ansible package & dependencies

### DIFF
--- a/centos-ci/bootstrap.sh
+++ b/centos-ci/bootstrap.sh
@@ -18,7 +18,8 @@ yum-builddep -y leapp.spec
 TERM=xterm tito build --rpm --test || (echo "Failed to build leapp RPM" && exit 1)
 # TODO: Actually install the built RPM & use that in the integration tests
 
-pip install ansible==2.2.0
+# Configure the system to run the integration tests
+yum install -y ansible
 
 cd centos-ci/ansible/
 


### PR DESCRIPTION
Some of Ansible's dependencies now use `cffi`, and hence require that
the `libffi` headers be available on the system when installed via `pip`.

Rather than ensuring that is the case directly, we instead install Ansible
from EPEL rather than PyPI.