### PR TITLE
Change output if Source/Target machine is not accessible via SSH

### DIFF
--- a/src/leappto/driver/ssh.py
+++ b/src/leappto/driver/ssh.py
@@ -37,7 +37,7 @@ class ParamikoConnection(object):
         try:
             self._socket.connect((hostname, port))
         except socket.error as e:
-            raise SSHConnectionError('Failed to connect to {}:{} ERROR: {}'.format(hostname, port, e.message))
+            raise SSHConnectionError('Failed to connect to {}:{} ERROR: {}'.format(hostname, port, e))
         self._transport = paramiko.Transport(self._socket)
 
         try:


### PR DESCRIPTION
- Display error message in case of a SSH Connection exception is raised;
- Check if target machine is accessible;
- Do not  show traceback in case of a SSH Connection exception.