### PR TITLE
Tidy up port scanning in the test suite

### DIFF
--- a/integration-tests/features/default-port-detection.feature
+++ b/integration-tests/features/default-port-detection.feature
@@ -5,7 +5,7 @@ Scenario: Return default port detected on source machine - discovered ports only
          | name       | definition          | ensure_fresh |
          | source     | centos6-guest-httpd | no          |
          | target     | centos7-target      | no          |
-     Then get list of discovered ports from source which will be forwared to target
+     Then get list of discovered ports from source which will be forwarded to target
 
 Scenario: Return default port detected on source machine - override port 80
    Given the local virtual machines:

--- a/integration-tests/features/environment.py
+++ b/integration-tests/features/environment.py
@@ -69,20 +69,20 @@ def before_feature(context, feature):
     # Use contextlib.ExitStack to manage per-feature resources
     context._feature_cleanup = contextlib.ExitStack()
 
+    # Each feature gets a VirtualMachineHelper instance
+    # VMs are relatively slow to start/stop, so by default, we defer halting
+    # or destroying them to the end of the overall test run
+    # Scenario steps can still opt in to eagerly cleaning up a scenario's VMs
+    # by doing `context.scenario_cleanup.callback(context.vm_helper.close)`
+    context.vm_helper = vm_helper = VirtualMachineHelper()
+    context._global_cleanup.callback(vm_helper.close)
+
 def before_scenario(context, scenario):
     if _skip_test_group(context, scenario):
         return
 
     # Each scenario has a contextlib.ExitStack instance for resource cleanup
     context.scenario_cleanup = contextlib.ExitStack()
-
-    # Each scenario gets a VirtualMachineHelper instance
-    # VMs are relatively slow to start/stop, so by default, we defer halting
-    # or destroying them to the end of the overall test run
-    # Feature steps can still opt in to eagerly cleaning up a scenario's VMs
-    # by doing `context.scenario_cleanup.callback(context.vm_helper.close)`
-    context.vm_helper = vm_helper = VirtualMachineHelper()
-    context._global_cleanup.callback(vm_helper.close)
 
     # Each scenario gets a ClientHelper instance
     context.cli_helper = cli_helper = ClientHelper(context.vm_helper)

--- a/integration-tests/features/port-inspect.feature
+++ b/integration-tests/features/port-inspect.feature
@@ -1,13 +1,13 @@
-Feature: Get information about used ports by virtual machine
+Feature: Get information about ports used by a remote machine
 
 Scenario: Return detailed informations about ports 22,80
    Given the local virtual machines:
          | name       | definition          | ensure_fresh |
          | vm         | centos6-guest-httpd | no           |
-     Then getting information about ports 22,80 used by 10.0.0.10 should take less than 15 seconds
+     Then getting information about ports 22,80 used by vm should take less than 20 seconds
 
-Scenario: Return information about all used ports by virtual machine
+Scenario: Return information about all ports used by virtual machine
    Given the local virtual machines:
          | name       | definition          | ensure_fresh |
          | vm         | centos6-guest-httpd | no           |
-     Then getting informations about all used ports by 10.0.0.10 should take less than 3 seconds
+     Then getting informations about all ports used by vm should take less than 10 seconds

--- a/integration-tests/features/steps/default-port-detection.py
+++ b/integration-tests/features/steps/default-port-detection.py
@@ -1,5 +1,5 @@
 """Steps to test the "scan-ports" subcommand"""
-from behave import then
+from behave import then, when
 from hamcrest import assert_that
 from hamcrest import equal_to 
 from json import loads
@@ -21,7 +21,7 @@ def _assert_discovered_ports(ports, expected_ports):
     assert_that(ports, equal_to(expected_ports))
 
 
-@then("get list of discovered ports from {vm_source_name} which will be forwared to {vm_target_name}")
+@then("get list of discovered ports from {vm_source_name} which will be forwarded to {vm_target_name}")
 def check_specific_ports_used_by_vm(context, vm_source_name, vm_target_name):
     """check if ports 22,80,111 are open and forwarded to 9022,80,112"""
 

--- a/integration-tests/features/steps/port_inspect.py
+++ b/integration-tests/features/steps/port_inspect.py
@@ -10,23 +10,24 @@ def _assert_discovered_ports(ports):
     assert_that(ports['ports'].get('tcp', False))
     assert_that(ports['ports']['tcp'].keys(), [22, 80])
 
+def _get_ip_address(context, name):
+    return context.vm_helper.get_ip_address(name)
 
-@then("getting information about ports {port_range} used by {vm_ip} should take less than {time_limit:g} seconds")
-def check_specific_ports_used_by_vm(context, vm_ip, port_range, time_limit):
+@then("getting information about ports {port_range} used by {vm_name} should take less than {time_limit:g} seconds")
+def check_specific_ports_used_by_vm(context, vm_name, port_range, time_limit):
     """check if ports 22,80 are open"""
     ports = context.cli_helper.check_response_time(
-        ["port-inspect", "--range", port_range, vm_ip],
+        ["port-inspect", "--range", port_range, _get_ip_address(context, vm_name)],
         time_limit
     )
     _assert_discovered_ports(ports)
 
 
-@then("getting informations about all used ports by {vm_ip} should take less than {time_limit:g} seconds")
-def check_all_used_ports_by_vm(context, vm_ip, time_limit):
+@then("getting informations about all ports used by {vm_name} should take less than {time_limit:g} seconds")
+def check_all_used_ports_by_vm(context, vm_name, time_limit):
     """check all used ports by vm, scan should be really fast"""
     ports = context.cli_helper.check_response_time(
-            ["port-inspect", "--shallow", vm_ip],
-            time_limit,
-            as_sudo=True
+            ["port-inspect", "--shallow", _get_ip_address(context, vm_name)],
+            time_limit
     )
     _assert_discovered_ports(ports)


### PR DESCRIPTION
- ClientHelper ensures commands that need sudo are
  always run with sudo
- IP addresses are no longer hard coded in test cases
- relaxed some of the timing requirements for test steps
- fixed some typos and awkward phrasing in step definitions

Fixes #165