### PR TITLE
[Proposal] Derive container name from source hostname

### DIFF
--- a/src/leappto/cli.py
+++ b/src/leappto/cli.py
@@ -603,9 +603,17 @@ def main():
 
         def destroy_containers(self):
             storage_dir = MACROCONTAINER_STORAGE_DIR
-            return self._ssh_sudo(
-                'docker rm -fv container 2>/dev/null 1>/dev/null; '
-                'rm -rf {}/*'.format(storage_dir))
+            rc, containers = self.check_target()
+            if rc:
+                return rc
+            for c in containers:
+                rc = self._ssh_sudo(
+                    'docker rm -fv {0} 2>/dev/null 1>/dev/null; '
+                    'rm -rf {1}/{0}'.format(c, storage_dir)
+                )
+                if rc:
+                    break
+            return rc
 
         def start_container(self, img, init):
             container_name = self._get_container_name()

--- a/src/leappto/cli.py
+++ b/src/leappto/cli.py
@@ -20,7 +20,6 @@ import sys
 import socket
 import nmap
 import shlex
-import shutil
 import errno
 
 

--- a/src/leappto/cli.py
+++ b/src/leappto/cli.py
@@ -537,7 +537,7 @@ def main():
 
                 self._open_permanent_ssh_conn(self.SOURCE)
                 try:
-                    ret_code, _ = self._ssh_sudo('sync && fsfreeze -f /', machine_context=self.SOURCE, reuse_ssh_conn=True)
+                    ret_code = self._ssh_sudo('sync && fsfreeze -f /', machine_context=self.SOURCE, reuse_ssh_conn=True)
                     if ret_code != 0:
                         sys.exit(ret_code)
 
@@ -569,7 +569,7 @@ def main():
                     proc = Popen(['sudo', 'bash', '-c', 'LIBGUESTFS_BACKEND=direct virt-tar-out -a {} / -' \
                                 .format(self.disk)], stdout=PIPE)
                     assert SOURCE_APP_EXPORT_DIR
-                    ret_code, _ = self._ssh_sudo(
+                    return self._ssh_sudo(
                         ('mkdir -p {0}/ && cat > {0}/exported_app.tar.gz && '
                          'tar xf {0}/exported_app.tar.gz -C {1} && '
                          'rm {0}/exported_app.tar.gz').format(
@@ -578,7 +578,6 @@ def main():
                         ),
                         stdin=proc.stdout
                     )
-                    return ret_code
                 finally:
                     print('! ', self.source.resume())
 
@@ -621,13 +620,11 @@ def main():
                 else:
                     command += ' -p {:d}:{:d}'.format(host_port, container_port)
             command += ' --name ' + container_name + ' ' + img + ' ' + init
-            ret_code, _ = self._ssh_sudo(command)
-            return ret_code
+            return self._ssh_sudo(command)
 
         def _fix_container(self, fix_str):
             container_name = self._get_container_name()
-            ret_code, _ = self._ssh_sudo('docker exec -t {} {}'.format(container_name, fix_str))
-            return ret_code
+            return self._ssh_sudo('docker exec -t {} {}'.format(container_name, fix_str))
 
         def fix_upstart(self):
             fixer = 'bash -c "echo ! waiting ; ' + \

--- a/src/leappto/cli.py
+++ b/src/leappto/cli.py
@@ -528,8 +528,6 @@ def main():
                 rsync_dir = container_dir
 
                 try:
-                    # temporary, after task with different names for containers rmtree should be removed
-                    shutil.rmtree(rsync_dir, ignore_errors=True)
                     os.makedirs(rsync_dir)
                 except OSError as exc:
                     if exc.errno != errno.EEXIST:  # raise exception if it's different than FileExists


### PR DESCRIPTION
Based on a TODO comment present on source code, this PR proposes:

- Instead of creating a container and a macro container directory with name "container" use "container_<source_hostname>" to make it easier to know from which machine such container was created;
- Enable user to define a specific container name during migration using --container-name or -n options.