### PR TITLE
cli: Fix check-target exception for localhost

### DIFF
--- a/src/leappto/cli.py
+++ b/src/leappto/cli.py
@@ -447,7 +447,7 @@ def main():
                 machine_context = self.TARGET
             machine = getattr(self, machine_context, None)
             if isinstance(machine, Machine) and machine.is_local:
-                return Popen(shlex.split(cmd))
+                return Popen(shlex.split(cmd), **kwargs)
             addr, cfg, use_sshpass = self.__get_machine_opt_by_context(machine_context)
             ssh_cmd = self._ssh_base(addr, cfg)
             if reuse_ssh_conn:


### PR DESCRIPTION
When executing check-target for localhost  (127.0.0.1) an exception occurred:
```
$ sudo bin/leapp-tool check-target 127.0.0.1
container
dreamy_lamarr
vibrant_stonebraker
RC: 0 Containers: None
Traceback (most recent call last):
  File "bin/leapp-tool.real", line 11, in <module>
    load_entry_point('leappto==0.0.1', 'console_scripts', 'leapp-tool')()
  File "/home/vfeenstr/.local/venvs/leappto/lib/python2.7/site-packages/leappto/cli.py", line 778, in main
    return_code, claimed_names = mc.check_target()
  File "/home/vfeenstr/.local/venvs/leappto/lib/python2.7/site-packages/leappto/cli.py", line 589, in check_target
    names = containers.splitlines()
AttributeError: 'NoneType' object has no attribute 'splitlines'
```

This PR solves this issue