### PR TITLE
Check target access early in migrate-machine

### DIFF
--- a/integration-tests/features/httpd-stateless.feature
+++ b/integration-tests/features/httpd-stateless.feature
@@ -7,9 +7,7 @@ Scenario: HTTP default server page
          | target     | centos7-target      | no           |
     When app-source is redeployed to target as a macrocontainer
     Then the HTTP 403 response on port 80 should match within 120 seconds
-     # TODO: Add a clause that ensures we check target viability *early*,
-     #       rather than leaving it until after exporting the source app
-     # And attempting a second redeployment should fail within 10 seconds
+     And attempting another redeployment should fail within 10 seconds
 
 Scenario: HTTP default server page - migrated by using rsync
    Given the local virtual machines:
@@ -18,6 +16,4 @@ Scenario: HTTP default server page - migrated by using rsync
          | target     | centos7-target      | no           |
     When app-source is redeployed to target as a macrocontainer and rsync is used for fs migration
     Then the HTTP 403 response on port 80 should match within 120 seconds
-     # TODO: Add a clause that ensures we check target viability *early*,
-     #       rather than leaving it until after exporting the source app
-     # And attempting a second redeployment should fail within 10 seconds
+     And attempting another redeployment should fail within 10 seconds

--- a/integration-tests/features/leapp_testing/__init__.py
+++ b/integration-tests/features/leapp_testing/__init__.py
@@ -260,9 +260,10 @@ class ClientHelper(object):
                                             add_default_identity=use_default_identity,
                                             is_migrate=is_migrate,
                                             as_sudo=as_sudo)
-            except subprocess.CalledProcessError:
+            except subprocess.CalledProcessError as exc:
                 if not expect_failure:
                     raise
+                cmd_output = exc.stdout
             else:
                 if expect_failure:
                     raise AssertionError("Command succeeded unexpectedly")


### PR DESCRIPTION
- migrate-machine port remapping moved into MigrationContext
- target access checked before calculating port mapping
- port mapping helpers moved to CLI module top level
- related test steps enabled