### PR TITLE
Do not fail check-target if running on an empty target machine

### DIFF
--- a/src/leappto/cli.py
+++ b/src/leappto/cli.py
@@ -615,11 +615,13 @@ def main():
             None
         )
 
-        return_code, claimed_names = mc.check_target()
+        _, claimed_names = mc.check_target()
         for name in sorted(claimed_names):
             print(name)
 
-        sys.exit(return_code)
+        # Even if failed to find any container this can be a normal run on new
+        # target machines, so do not return an error code
+        sys.exit()
 
     elif parsed.action == 'destroy-containers':
         target = parsed.target


### PR DESCRIPTION
Do not return any error code after a 'leapp-tool check-target', since not finding any container should be fine on an empty target machine. This should fix issue #190 