### PR TITLE
enable concurrent runs

### DIFF
--- a/centos-ci/jobs/integration_test.yml
+++ b/centos-ci/jobs/integration_test.yml
@@ -8,6 +8,7 @@
       - github:
           url: https://github.com/leapp-to/prototype
     node: leapp
+    concurrent: true
     scm:
       - github-scm:
           git_url: https://github.com/leapp-to/prototype.git


### PR DESCRIPTION
this would allow upto 4 runs of the job to execute in parallel, they would run from their own workspace and run on their own worker nodes, so should not impact each other.

the only place where this might cause an issue is when there is state or some config maintained outside the specific workspace. it might be good to watch closely the first few runs.