### PR TITLE
Selective container removal and forced creation

### DIFF
--- a/integration-tests/features/destroy-containers.feature
+++ b/integration-tests/features/destroy-containers.feature
@@ -1,9 +1,25 @@
-Feature: Destroy existing macrocontainers on target virtual machine 
+Feature: Destroy existing macrocontainers on target virtual machine
 
 Scenario: Destroying macrocontainers on target VM
    Given the local virtual machines:
          | name       | definition          | ensure_fresh |
-         | app-source | centos6-guest-httpd | no           |
          | target     | centos7-target      | no           |
-    When app-source is redeployed to target as a macrocontainer
-    Then destroying existing macrocontainers on target should take less than 60 seconds
+     And the following names claimed on target:
+         | name       | kind                |
+         | app1       | idle macrocontainer |
+         | app2       | idle macrocontainer |
+         | container1 | idle container      |
+         | container2 | idle container      |
+         | storage1   | macrocontainer dir  |
+         | storage2   | macrocontainer dir  |
+    Then destroying app1 on target should take less than 10 seconds
+     And "app1" should no longer be reported as in use
+     And all remaining claimed names should still be reported as in use
+    Then destroying container1 on target should take less than 10 seconds
+     And "container1" should no longer be reported as in use
+     And all remaining claimed names should still be reported as in use
+    Then destroying storage1 on target should take less than 10 seconds
+     And "storage1" should no longer be reported as in use
+     And all remaining claimed names should still be reported as in use
+    Then destroying nonexistent on target should take less than 10 seconds
+     And all remaining claimed names should still be reported as in use

--- a/integration-tests/features/httpd-stateless.feature
+++ b/integration-tests/features/httpd-stateless.feature
@@ -5,15 +5,27 @@ Scenario: HTTP default server page
          | name       | definition          | ensure_fresh |
          | app-source | centos6-guest-httpd | no           |
          | target     | centos7-target      | no           |
-    When app-source is redeployed to target as a macrocontainer
+    When app-source is migrated to target as a macrocontainer
     Then the HTTP 403 response on port 80 should match within 120 seconds
-     And attempting another redeployment should fail within 10 seconds
+     And attempting another migration should fail within 10 seconds
 
 Scenario: HTTP default server page - migrated by using rsync
    Given the local virtual machines:
          | name       | definition          | ensure_fresh |
          | app-source | centos6-guest-httpd | no           |
          | target     | centos7-target      | no           |
-    When app-source is redeployed to target as a macrocontainer and rsync is used for fs migration
+    When app-source is migrated to target as a macrocontainer and rsync is used for fs migration
     Then the HTTP 403 response on port 80 should match within 120 seconds
-     And attempting another redeployment should fail within 10 seconds
+     And attempting another migration should fail within 10 seconds
+
+Scenario: Forced migration overwriting an existing container
+   Given the local virtual machines:
+         | name       | definition          | ensure_fresh |
+         | app-source | centos6-guest-httpd | no           |
+         | target     | centos7-target      | no           |
+     And the following names claimed on target:
+         | name       | kind                |
+         | migrated   | idle macrocontainer |
+   Then migrating app-source to target as "migrated" should fail within 10 seconds
+    And attempting another migration with forced creation should succeed within 120 seconds
+    And the HTTP 403 response on port 80 should match within 120 seconds

--- a/integration-tests/features/leapp_testing/__init__.py
+++ b/integration-tests/features/leapp_testing/__init__.py
@@ -184,35 +184,6 @@ def install_client():
     # Ensure private SSH key is only readable by the current user
     os.chmod(_SSH_IDENTITY, 0o600)
 
-@attributes
-class MigrationInfo(object):
-    """Details of local hosts involved in an app migration command
-
-    *local_vm_count*: Total number of local VMs found during migration
-    *source_ip*: host accessible IP address found for source VM
-    *target_ip*: host accessible IP address found for target VM
-    *command_succeeded*: True if the command return code was 0
-    *command_failed*: logical inverse of command_succeeded
-    """
-    local_vm_count = attrib()
-    source_ip = attrib()
-    target_ip = attrib()
-
-    @classmethod
-    def from_vm_list(cls, machines, source_host, target_host):
-        """Build a result given a local VM listing and migration hostnames"""
-        vm_count = len(machines)
-        source_ip = target_ip = None
-        for machine in machines:
-            if machine["hostname"] == source_host:
-                source_ip = machine["ip"][0]
-            if machine["hostname"] == target_host:
-                target_ip = machine["ip"][0]
-            if source_ip is not None and target_ip is not None:
-                break
-        return cls(vm_count, source_ip, target_ip)
-
-
 
 class ClientHelper(object):
     """Test step helper to invoke the LeApp CLI
@@ -223,20 +194,32 @@ class ClientHelper(object):
     def __init__(self, vm_helper):
         self._vm_helper = vm_helper
 
-    def make_migration_command(self, source_vm, target_vm, migration_opt=None):
+    def make_migration_command(self, source_vm, target_vm,
+                               migration_opt=None,
+                               force_create=False,
+                               container_name=None):
         """Get command to recreate source VM as a macrocontainer on given target VM"""
         vm_helper = self._vm_helper
         source_host = vm_helper.get_hostname(source_vm)
         target_host = vm_helper.get_hostname(target_vm)
-        return self._make_redeployment_command(source_host, target_host, migration_opt)
+        return self._make_migration_command(
+            source_host,
+            target_host,
+            migration_opt,
+            force_create,
+            container_name
+        )
 
-    def redeploy_as_macrocontainer(self, source_vm, target_vm, migration_opt=None):
+    def migrate_as_macrocontainer(self, source_vm, target_vm, migration_opt=None):
         """Recreate source VM as a macrocontainer on given target VM"""
         vm_helper = self._vm_helper
         source_host = vm_helper.get_hostname(source_vm)
         target_host = vm_helper.get_hostname(target_vm)
-        self._convert_vm_to_macrocontainer(source_host, target_host, migration_opt)
-        return self._get_migration_host_info(source_host, target_host)
+        return self._convert_vm_to_macrocontainer(
+            source_host,
+            target_host,
+            migration_opt
+        )
 
     def check_target(self, target_vm, time_limit=10):
         """Check viability of target VM and report currently unavailable names"""
@@ -363,32 +346,32 @@ class ClientHelper(object):
         return _run_command(cmd, work_dir=str(_LEAPP_BIN_DIR))
 
     @classmethod
-    def _make_redeployment_command(cls, source_host, target_host, migration_opt):
+    def _make_migration_command(cls, source_host, target_host, migration_opt,
+                                force_create=False,
+                                container_name=None):
         cmd_args = ["migrate-machine", "--tcp-port", "80:80"]
         if migration_opt == 'rsync':
             cmd_args.append('--use-rsync')
-        cmd_args.extend(["-t", target_host, source_host])
+        if force_create:
+            cmd_args.append('--force-create')
+        if container_name is not None:
+            cmd_args.extend(('--container-name', container_name))
+        cmd_args.extend(("-t", target_host, source_host))
         return cmd_args
 
     @classmethod
     def _convert_vm_to_macrocontainer(cls, source_host, target_host, migration_opt):
         as_sudo = False
-        cmd_args = cls._make_redeployment_command(source_host, target_host, migration_opt)
+        cmd_args = cls._make_migration_command(source_host, target_host, migration_opt)
         if '--use-rsync' in cmd_args:
             as_sudo = True
         result = cls._run_leapp(cmd_args,
                                 add_default_user=True,
                                 add_default_identity=True,
                                 is_migrate=True)
-        msg = "Redeployed {} as macrocontainer on {}"
+        msg = "Migrated {} as macrocontainer on {}"
         print(msg.format(source_host, target_host))
         return result
-
-    @classmethod
-    def _get_migration_host_info(cls, source_host, target_host):
-        leapp_output = cls._run_leapp(["list-machines", "--shallow"])
-        machines = json.loads(leapp_output)["machines"]
-        return MigrationInfo.from_vm_list(machines, source_host, target_host)
 
 
 ##############################
@@ -450,12 +433,12 @@ class RequestsHelper(object):
         return responses
 
     @classmethod
-    def compare_redeployed_response(cls, original_ip, redeployed_ip, *,
+    def compare_migrated_response(cls, original_ip, migrated_ip, *,
                                     tcp_port, status, wait_for_target):
-        """Compare a pre-migration app response with a redeployed response
+        """Compare a pre-migration app response with a post-migration response
 
         Expects an immediate response from the original IP, and allows for
-        a delay before the redeployment target starts returning responses
+        a delay before the migration target starts returning responses
         """
         # Get response from source VM
         original_url = "http://{}:{}".format(original_ip, tcp_port)
@@ -464,11 +447,13 @@ class RequestsHelper(object):
         original_status = original_response.status_code
         assert_that(original_status, equal_to(status), "Original status")
         # Get response from target VM
-        redeployed_url = "http://{}:{}".format(redeployed_ip, tcp_port)
-        redeployed_response = cls.get_response(redeployed_url, wait_for_target)
-        print("Response received from {}".format(redeployed_url))
+        migrated_url = "http://{}:{}".format(migrated_ip, tcp_port)
+        migrated_response = cls.get_response(migrated_url, wait_for_target)
+        print("Response received from {}".format(migrated_url))
         # Compare the responses
-        assert_that(redeployed_response.status_code, equal_to(original_status), "Redeployed status")
+        assert_that(migrated_response.status_code,
+                    equal_to(original_status),
+                    "Post-migration status code didn't match original")
         original_data = original_response.text
-        redeployed_data = redeployed_response.text
-        assert_that(redeployed_data, equal_to(original_data), "Same response")
+        migrated_data = migrated_response.text
+        assert_that(migrated_data, equal_to(original_data), "Same response")

--- a/integration-tests/features/leapp_testing/__init__.py
+++ b/integration-tests/features/leapp_testing/__init__.py
@@ -238,6 +238,16 @@ class ClientHelper(object):
         self._convert_vm_to_macrocontainer(source_host, target_host, migration_opt)
         return self._get_migration_host_info(source_host, target_host)
 
+    def check_target(self, target_vm, time_limit=10):
+        """Check viability of target VM and report currently unavailable names"""
+        command_output = self.check_response_time(
+            ["check-target", self._vm_helper.get_hostname(target_vm)],
+            time_limit,
+            use_default_identity=True
+        )
+        return command_output.splitlines()
+
+
     def check_response_time(self, cmd_args, time_limit, *,
                             specify_default_user=False,
                             use_default_identity=False,

--- a/integration-tests/features/steps/check_target.py
+++ b/integration-tests/features/steps/check_target.py
@@ -62,12 +62,7 @@ def claim_names_on_target_vm(context, target):
 @then("checking {target} usability should take less than {time_limit:g} seconds")
 def run_check_target(context, target, time_limit):
     """Retrieve claimed names from designated target"""
-    command_output = context.cli_helper.check_response_time(
-        ["check-target", context.vm_helper.get_hostname(target)],
-        time_limit,
-        use_default_identity=True
-    )
-    context._reported_names = command_output.splitlines()
+    context._reported_names = context.cli_helper.check_target(target, time_limit)
 
 @then("all claimed names should be reported exactly once")
 def check_claimed_names(context):

--- a/integration-tests/features/steps/common.py
+++ b/integration-tests/features/steps/common.py
@@ -1,4 +1,4 @@
-"""Common steps for macrocontainer redeployment testing
+"""Common steps for macrocontainer migration testing
 
 All steps in this file should only assume access to the LeApp CLI client,
 to allow testing of behaviour without the DBus service running.
@@ -46,37 +46,58 @@ def create_local_machines(context, user=None):
 # Leapp commands
 ##############################
 
-@when("{source_vm} is redeployed to {target_vm} as a macrocontainer")
-@when("{source_vm} is redeployed to {target_vm} as a macrocontainer and {migration_opt} is used for fs migration")
-def redeploy_vm_as_macrocontainer(context, source_vm, target_vm, migration_opt=None):
-    """Uses leapp-tool.py to redeploy the given source VM
+@when("{source_vm} is migrated to {target_vm} as a macrocontainer")
+@when("{source_vm} is migrated to {target_vm} as a macrocontainer and {migration_opt} is used for fs migration")
+def migrate_vm_as_macrocontainer(context, source_vm, target_vm, migration_opt=None):
+    """Uses leapp-tool.py to migrate the given source VM
 
     Both *source_vm* and *target_vm* must be named in a previous local
     virtual machine creation table.
     """
-    context.redeployment_source = source_vm
-    context.redeployment_target = target_vm
-    context.redeployment_migration_opt = migration_opt
-    redeploy_app = context.cli_helper.redeploy_as_macrocontainer
-    vm_info = redeploy_app(source_vm, target_vm, migration_opt)
-    assert_that(vm_info.local_vm_count, greater_than(1), "At least 2 local VMs")
-    assert_that(vm_info.source_ip, not_none(), "Valid source IP")
-    assert_that(vm_info.target_ip, not_none(), "Valid target IP")
-    context.redeployment_source_ip = vm_info.source_ip
-    context.redeployment_target_ip = vm_info.target_ip
+    context.migration_source = source_vm
+    context.migration_target = target_vm
+    context.migration_migration_opt = migration_opt
+    migrate_app = context.cli_helper.migrate_as_macrocontainer
+    assert_that(migrate_app(source_vm, target_vm, migration_opt), equal_to(0))
 
-@then("attempting another redeployment should fail within {time_limit:g} seconds")
-def repeat_previous_redeployment(context, time_limit):
-    """Attempts to repeat a previously executed redeployment command"""
-    source_vm = context.redeployment_source
-    target_vm = context.redeployment_target
-    migration_opt = context.redeployment_migration_opt
+@then("attempting another migration should fail within {time_limit:g} seconds")
+def repeat_previous_migration(context, time_limit):
+    """Attempts to repeat a previously executed migration command"""
+    source_vm = context.migration_source
+    target_vm = context.migration_target
+    migration_opt = context.migration_migration_opt
     helper = context.cli_helper
     cmd_args = helper.make_migration_command(source_vm, target_vm, migration_opt)
     output = helper.check_response_time(cmd_args, time_limit,
                                         use_default_identity=True,
                                         expect_failure=True)
     assert_that(output, is_not(equal_to("")))
+
+@then('migrating {source_vm} to {target_vm} as "{app_name}" should fail within {time_limit:g} seconds')
+def expect_failed_migration(context, source_vm, target_vm, app_name, time_limit):
+    context.migration_source = source_vm
+    context.migration_target = target_vm
+    context.migrated_app = app_name
+    context.migration_migration_opt = migration_opt = "rsync"
+    helper = context.cli_helper
+    cmd_args = helper.make_migration_command(source_vm, target_vm, migration_opt,
+                                             container_name=app_name)
+    output = helper.check_response_time(cmd_args, time_limit,
+                                        use_default_identity=True,
+                                        expect_failure=True)
+    assert_that(output, is_not(equal_to("")))
+
+@then("attempting another migration with forced creation should succeed within {time_limit:g} seconds")
+def force_app_migration(context, time_limit):
+    source_vm = context.migration_source
+    target_vm = context.migration_target
+    app_name = context.migrated_app
+    migration_opt = context.migration_migration_opt
+    helper = context.cli_helper
+    cmd_args = helper.make_migration_command(source_vm, target_vm, migration_opt,
+                                             container_name=app_name,
+                                             force_create=True)
+    output = helper.check_response_time(cmd_args, time_limit, use_default_identity=True)
 
 
 ##############################
@@ -88,15 +109,18 @@ def check_http_responses_match(context, tcp_port, status, time_limit):
     """Checks a macrocontainer response matches the original VM's response
 
     The source and target VM are inferred from the most recent preceding
-    redeployment step.
+    migration step.
     """
-    original_ip = context.redeployment_source_ip
-    redeployed_ip = context.redeployment_target_ip
+    source_vm = context.migration_source
+    target_vm = context.migration_target
+
+    original_ip = context.vm_helper.get_ip_address(source_vm)
+    migrated_ip = context.vm_helper.get_ip_address(target_vm)
     assert_that(original_ip, not_none(), "Valid original IP")
-    assert_that(redeployed_ip, not_none(), "Valid redeployment IP")
-    context.http_helper.compare_redeployed_response(
+    assert_that(migrated_ip, not_none(), "Valid migration IP")
+    context.http_helper.compare_migrated_response(
         original_ip,
-        redeployed_ip,
+        migrated_ip,
         tcp_port=tcp_port,
         status=status,
         wait_for_target=time_limit

--- a/integration-tests/features/steps/common.py
+++ b/integration-tests/features/steps/common.py
@@ -58,7 +58,8 @@ def migrate_vm_as_macrocontainer(context, source_vm, target_vm, migration_opt=No
     context.migration_target = target_vm
     context.migration_migration_opt = migration_opt
     migrate_app = context.cli_helper.migrate_as_macrocontainer
-    assert_that(migrate_app(source_vm, target_vm, migration_opt), equal_to(0))
+    output = migrate_app(source_vm, target_vm, migration_opt)
+    # TODO: Assert specifics regarding expected output
 
 @then("attempting another migration should fail within {time_limit:g} seconds")
 def repeat_previous_migration(context, time_limit):
@@ -72,6 +73,7 @@ def repeat_previous_migration(context, time_limit):
                                         use_default_identity=True,
                                         expect_failure=True)
     assert_that(output, is_not(equal_to("")))
+    # TODO: Assert specifics regarding expected output
 
 @then('migrating {source_vm} to {target_vm} as "{app_name}" should fail within {time_limit:g} seconds')
 def expect_failed_migration(context, source_vm, target_vm, app_name, time_limit):
@@ -86,6 +88,7 @@ def expect_failed_migration(context, source_vm, target_vm, app_name, time_limit)
                                         use_default_identity=True,
                                         expect_failure=True)
     assert_that(output, is_not(equal_to("")))
+    # TODO: Assert specifics regarding expected output
 
 @then("attempting another migration with forced creation should succeed within {time_limit:g} seconds")
 def force_app_migration(context, time_limit):
@@ -98,6 +101,7 @@ def force_app_migration(context, time_limit):
                                              container_name=app_name,
                                              force_create=True)
     output = helper.check_response_time(cmd_args, time_limit, use_default_identity=True)
+    # TODO: Assert specifics regarding expected output
 
 
 ##############################

--- a/integration-tests/features/steps/destroy_containers.py
+++ b/integration-tests/features/steps/destroy_containers.py
@@ -4,7 +4,7 @@ from hamcrest import assert_that, equal_to, not_, is_in
 
 
 @then("destroying {container} on {target} should take less than {time_limit:g} seconds")
-def check_destroy_containers(context, container, target, time_limit):
+def check_destroy_container(context, container, target, time_limit):
     """Destroy named container on named VM"""
     claimed_names = getattr(context, "_claimed_names")
     if not claimed_names:

--- a/integration-tests/features/steps/destroy_containers.py
+++ b/integration-tests/features/steps/destroy_containers.py
@@ -1,12 +1,29 @@
 """Steps to test the "destroy-containers" subcommand"""
 from behave import then
+from hamcrest import assert_that, equal_to, not_, is_in
 
 
-@then("destroying existing macrocontainers on {target} should take less than {time_limit:g} seconds")
-def check_destroy_containers(context, target, time_limit):
-    """check if exisiting containers have been destroyed"""
+@then("destroying {container} on {target} should take less than {time_limit:g} seconds")
+def check_destroy_containers(context, container, target, time_limit):
+    """Destroy named container on named VM"""
+    claimed_names = getattr(context, "_claimed_names")
+    if not claimed_names:
+        raise RuntimeError("Claim names in test scenario setup to use this step")
     context.cli_helper.check_response_time(
-        ["destroy-containers", context.vm_helper.get_hostname(target)],
+        ["destroy-container", context.vm_helper.get_hostname(target), container],
         time_limit,
         use_default_identity=True
     )
+    if container in claimed_names:
+        claimed_names.remove(container)
+    context._reported_names = context.cli_helper.check_target(target)
+
+@then('"{container}" should no longer be reported as in use')
+def check_deleted_name_no_longer_reported(context, container):
+    """Check deleted container is no longer reported as in use"""
+    assert_that(container, not_(is_in(context._reported_names)))
+
+@then("all remaining claimed names should still be reported as in use")
+def check_other_claimed_names(context):
+    """Check claimed names match those in the expected list"""
+    assert_that(context._reported_names, equal_to(context._claimed_names))

--- a/src/leappto/cli.py
+++ b/src/leappto/cli.py
@@ -400,9 +400,9 @@ def main():
             ls_storage_directories = 'ls -1 "{}"'.format(storage_dir)
             rc, dirs = self._ssh_sudo_out(ls_storage_directories,
                                           machine_context=self.TARGET)
-            if rc:
-                return rc, []
-            names.extend(dirs.splitlines())
+            # Ignore remote ls failures, as migrate-machine will create the dir if needed
+            if rc == 0:
+                names.extend(dirs.splitlines())
             return 0, sorted(set(names))
 
         def map_ports(self, use_default_port_map=True, forwarded_tcp_ports=None, excluded_tcp_ports=None, print_info=print):


### PR DESCRIPTION
- adds `migrate-machine --force-create`
- replaces `destroy-containers` with `destroy-container <name>`

Also updates the integration tests and integrating testing
infrastructure accordingly.