### PR TITLE
Disabled default port mapping for migration executed from UI

### DIFF
--- a/cockpit/leapp.html
+++ b/cockpit/leapp.html
@@ -685,6 +685,7 @@
             var import_args = ["migrate-machine"]
             import_args.push("--use-rsync");
             override_identity(import_args);
+            import_args.push("--ignore-default-port-map");
             import_args.push("--tcp-port");
             Array.prototype.push.apply(import_args, mapped_ports)
             import_args.push("-t", target, source)


### PR DESCRIPTION
The default mapping will cause, that port found by default mapping will be added although the checkbox is not checked. Therefore, an parameter was added into the command executed from UI to disable this behavior.